### PR TITLE
Added possibility to deselect assets when showing picker.

### DIFF
--- a/DKImagePickerController/DKImagePickerController.swift
+++ b/DKImagePickerController/DKImagePickerController.swift
@@ -103,6 +103,8 @@ public class DKImagePickerController: UINavigationController {
 			}
 		}
 	}
+    /// This allows to clear @selectedAssets without creating new picker each time
+    public var shouldDeselectAssets: Bool = false
 	
     /// The callback block is executed when user pressed the select button.
     public var didSelectAssets: ((assets: [DKAsset]) -> Void)?
@@ -170,6 +172,10 @@ public class DKImagePickerController: UINavigationController {
 				rootVC.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: self.doneButton)
 			}
 		}
+
+        if shouldDeselectAssets {
+            self.selectedAssets.removeAll()
+        }
 	}
 	
 	private lazy var assetFetchOptions: PHFetchOptions = {

--- a/DKImagePickerControllerDemo/ViewController.swift
+++ b/DKImagePickerControllerDemo/ViewController.swift
@@ -30,7 +30,8 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         allowMultipleType: Bool,
         sourceType: DKImagePickerControllerSourceType = [.Camera, .Photo],
 		allowsLandscape: Bool,
-		singleSelect: Bool) {
+		singleSelect: Bool,
+        shouldDeselect: Bool) {
             
             let pickerController = DKImagePickerController()
             pickerController.assetType = assetType
@@ -42,6 +43,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
 //			pickerController.showsEmptyAlbums = false
 //			pickerController.defaultAssetGroup = PHAssetCollectionSubtype.SmartAlbumFavorites
 			pickerController.defaultSelectedAssets = self.assets
+            pickerController.shouldDeselectAssets = shouldDeselect
             
             pickerController.didSelectAssets = { [unowned self] (assets: [DKAsset]) in
                 print("didSelectAssets")
@@ -87,13 +89,13 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     
     struct Demo {
         static let titles = [
-            ["Pick All", "Pick photos only", "Pick videos only", "Pick All (only photos or videos)"],
+            ["Pick All", "Pick photos only", "Pick videos only", "Pick All (only photos or videos)", "Pick All (new selection each time)"],
             ["Take a picture"],
             ["Hides camera"],
 			["Allows landscape"],
 			["Single select"]
         ]
-        static let types: [DKImagePickerControllerAssetType] = [.AllAssets, .AllPhotos, .AllVideos, .AllAssets]
+        static let types: [DKImagePickerControllerAssetType] = [.AllAssets, .AllPhotos, .AllVideos, .AllAssets, .AllAssets]
     }
     
     func numberOfSectionsInTableView(tableView: UITableView) -> Int {
@@ -121,13 +123,15 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
 			(indexPath.section == 2 ? .Photo : [.Camera, .Photo])
 		let allowsLandscape = indexPath.section == 3
 		let singleSelect = indexPath.section == 4
-		
+		let shouldDeselect = indexPath.section == 0 && indexPath.row == 4
+
 		showImagePickerWithAssetType(
 			assetType,
 			allowMultipleType: allowMultipleType,
 			sourceType: sourceType,
 			allowsLandscape: allowsLandscape,
-			singleSelect: singleSelect
+			singleSelect: singleSelect,
+            shouldDeselect: shouldDeselect
 		)
 	}
 	


### PR DESCRIPTION
If DKImagePickerController is used in some VC multiple time it might be useful sometimes to clear selection on each use.
i.e. There is VC to add new images with some custom titles, etc to 'posts feed'. User can choose maximum X posts, but he can display picker multiple time. As each time all selected photos are used in application VC, picker should show no selection each time it's shown.