### PR TITLE
Possibility to deselect assets when displaying picker for second time.

### DIFF
--- a/DKImagePickerController/DKImagePickerController.swift
+++ b/DKImagePickerController/DKImagePickerController.swift
@@ -103,6 +103,8 @@ public class DKImagePickerController: UINavigationController {
 			}
 		}
 	}
+    /// This allows to clear @selectedAssets without creating new picker each time
+    public var shouldDeselectAssets: Bool = false
 	
     /// The callback block is executed when user pressed the select button.
     public var didSelectAssets: ((assets: [DKAsset]) -> Void)?
@@ -169,7 +171,14 @@ public class DKImagePickerController: UINavigationController {
 				self.setViewControllers([rootVC], animated: false)
 				rootVC.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: self.doneButton)
 			}
-		}
+        } else if shouldDeselectAssets {
+            if let collectionVC = viewControllers[0] as? DKAssetGroupDetailVC {
+                for asset in selectedAssets {
+                    unselectedImage(asset)
+                }
+                collectionVC.collectionView?.reloadData()
+            }
+        }
 	}
 	
 	private lazy var assetFetchOptions: PHFetchOptions = {

--- a/DKImagePickerController/DKImagePickerController.swift
+++ b/DKImagePickerController/DKImagePickerController.swift
@@ -103,8 +103,6 @@ public class DKImagePickerController: UINavigationController {
 			}
 		}
 	}
-    /// This allows to clear @selectedAssets without creating new picker each time
-    public var shouldDeselectAssets: Bool = false
 	
     /// The callback block is executed when user pressed the select button.
     public var didSelectAssets: ((assets: [DKAsset]) -> Void)?
@@ -172,10 +170,6 @@ public class DKImagePickerController: UINavigationController {
 				rootVC.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: self.doneButton)
 			}
 		}
-
-        if shouldDeselectAssets {
-            self.selectedAssets.removeAll()
-        }
 	}
 	
 	private lazy var assetFetchOptions: PHFetchOptions = {

--- a/DKImagePickerController/DKImagePickerController.swift
+++ b/DKImagePickerController/DKImagePickerController.swift
@@ -103,6 +103,8 @@ public class DKImagePickerController: UINavigationController {
 			}
 		}
 	}
+    /// This allows to clear @selectedAssets without creating new picker each time
+    public var shouldDeselectAssets: Bool = false
 	
     /// The callback block is executed when user pressed the select button.
     public var didSelectAssets: ((assets: [DKAsset]) -> Void)?
@@ -170,6 +172,10 @@ public class DKImagePickerController: UINavigationController {
 				rootVC.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: self.doneButton)
 			}
 		}
+
+        if shouldDeselectAssets {
+            self.selectedAssets.removeAll()
+        }
 	}
 	
 	private lazy var assetFetchOptions: PHFetchOptions = {

--- a/DKImagePickerControllerDemo/ViewController.swift
+++ b/DKImagePickerControllerDemo/ViewController.swift
@@ -30,7 +30,8 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         allowMultipleType: Bool,
         sourceType: DKImagePickerControllerSourceType = [.Camera, .Photo],
 		allowsLandscape: Bool,
-		singleSelect: Bool) {
+		singleSelect: Bool,
+        shouldDeselect: Bool) {
             
             let pickerController = DKImagePickerController()
             pickerController.assetType = assetType
@@ -42,6 +43,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
 //			pickerController.showsEmptyAlbums = false
 //			pickerController.defaultAssetGroup = PHAssetCollectionSubtype.SmartAlbumFavorites
 			pickerController.defaultSelectedAssets = self.assets
+            pickerController.shouldDeselectAssets = shouldDeselect
             
             pickerController.didSelectAssets = { [unowned self] (assets: [DKAsset]) in
                 print("didSelectAssets")
@@ -87,13 +89,13 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     
     struct Demo {
         static let titles = [
-            ["Pick All", "Pick photos only", "Pick videos only", "Pick All (only photos or videos)"],
+            ["Pick All", "Pick photos only", "Pick videos only", "Pick All (only photos or videos)", "Pick All (new selection each time)"],
             ["Take a picture"],
             ["Hides camera"],
 			["Allows landscape"],
 			["Single select"]
         ]
-        static let types: [DKImagePickerControllerAssetType] = [.AllAssets, .AllPhotos, .AllVideos, .AllAssets]
+        static let types: [DKImagePickerControllerAssetType] = [.AllAssets, .AllPhotos, .AllVideos, .AllAssets, .AllAssets]
     }
     
     func numberOfSectionsInTableView(tableView: UITableView) -> Int {
@@ -121,13 +123,15 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
 			(indexPath.section == 2 ? .Photo : [.Camera, .Photo])
 		let allowsLandscape = indexPath.section == 3
 		let singleSelect = indexPath.section == 4
-		
+		let shouldDeselect = indexPath.section == 0 && indexPath.row == 4
+
 		showImagePickerWithAssetType(
 			assetType,
 			allowMultipleType: allowMultipleType,
 			sourceType: sourceType,
 			allowsLandscape: allowsLandscape,
-			singleSelect: singleSelect
+			singleSelect: singleSelect,
+            shouldDeselect: shouldDeselect
 		)
 	}
 	

--- a/DKImagePickerControllerDemo/ViewController.swift
+++ b/DKImagePickerControllerDemo/ViewController.swift
@@ -30,8 +30,7 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         allowMultipleType: Bool,
         sourceType: DKImagePickerControllerSourceType = [.Camera, .Photo],
 		allowsLandscape: Bool,
-		singleSelect: Bool,
-        shouldDeselect: Bool) {
+		singleSelect: Bool) {
             
             let pickerController = DKImagePickerController()
             pickerController.assetType = assetType
@@ -43,7 +42,6 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
 //			pickerController.showsEmptyAlbums = false
 //			pickerController.defaultAssetGroup = PHAssetCollectionSubtype.SmartAlbumFavorites
 			pickerController.defaultSelectedAssets = self.assets
-            pickerController.shouldDeselectAssets = shouldDeselect
             
             pickerController.didSelectAssets = { [unowned self] (assets: [DKAsset]) in
                 print("didSelectAssets")
@@ -89,13 +87,13 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     
     struct Demo {
         static let titles = [
-            ["Pick All", "Pick photos only", "Pick videos only", "Pick All (only photos or videos)", "Pick All (new selection each time)"],
+            ["Pick All", "Pick photos only", "Pick videos only", "Pick All (only photos or videos)"],
             ["Take a picture"],
             ["Hides camera"],
 			["Allows landscape"],
 			["Single select"]
         ]
-        static let types: [DKImagePickerControllerAssetType] = [.AllAssets, .AllPhotos, .AllVideos, .AllAssets, .AllAssets]
+        static let types: [DKImagePickerControllerAssetType] = [.AllAssets, .AllPhotos, .AllVideos, .AllAssets]
     }
     
     func numberOfSectionsInTableView(tableView: UITableView) -> Int {
@@ -123,15 +121,13 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
 			(indexPath.section == 2 ? .Photo : [.Camera, .Photo])
 		let allowsLandscape = indexPath.section == 3
 		let singleSelect = indexPath.section == 4
-		let shouldDeselect = indexPath.section == 0 && indexPath.row == 4
-
+		
 		showImagePickerWithAssetType(
 			assetType,
 			allowMultipleType: allowMultipleType,
 			sourceType: sourceType,
 			allowsLandscape: allowsLandscape,
-			singleSelect: singleSelect,
-            shouldDeselect: shouldDeselect
+			singleSelect: singleSelect
 		)
 	}
 	

--- a/DKImagePickerControllerDemo/ViewController.swift
+++ b/DKImagePickerControllerDemo/ViewController.swift
@@ -12,7 +12,8 @@ import Photos
 
 class ViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, UICollectionViewDataSource, UICollectionViewDelegate {
     var player: MPMoviePlayerController?
-    
+    var cachedPicker : DKImagePickerController?
+
     @IBOutlet var previewView: UICollectionView?
     var assets: [DKAsset]?
     
@@ -30,28 +31,40 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
         allowMultipleType: Bool,
         sourceType: DKImagePickerControllerSourceType = [.Camera, .Photo],
 		allowsLandscape: Bool,
-		singleSelect: Bool) {
-            
-            let pickerController = DKImagePickerController()
-            pickerController.assetType = assetType
-			pickerController.allowsLandscape = allowsLandscape
-			pickerController.allowMultipleTypes = allowMultipleType
-			pickerController.sourceType = sourceType
-			pickerController.singleSelect = singleSelect
-//			pickerController.showsCancelButton = true
-//			pickerController.showsEmptyAlbums = false
-//			pickerController.defaultAssetGroup = PHAssetCollectionSubtype.SmartAlbumFavorites
-			pickerController.defaultSelectedAssets = self.assets
-            
+		singleSelect: Bool,
+        shouldDeselect: Bool) {
+
+            let pickerController : DKImagePickerController
+
+            if let cachedPicker = cachedPicker where shouldDeselect == true {
+                pickerController = cachedPicker
+                pickerController.defaultSelectedAssets = nil
+            } else {
+               pickerController = DKImagePickerController()
+                if shouldDeselect {
+                    cachedPicker = pickerController
+                }
+                pickerController.assetType = assetType
+                pickerController.allowsLandscape = allowsLandscape
+                pickerController.allowMultipleTypes = allowMultipleType
+                pickerController.sourceType = sourceType
+                pickerController.singleSelect = singleSelect
+                //			pickerController.showsCancelButton = true
+                //			pickerController.showsEmptyAlbums = false
+                //			pickerController.defaultAssetGroup = PHAssetCollectionSubtype.SmartAlbumFavorites
+                pickerController.shouldDeselectAssets = shouldDeselect
+                pickerController.defaultSelectedAssets = self.assets
+            }
+
             pickerController.didSelectAssets = { [unowned self] (assets: [DKAsset]) in
                 print("didSelectAssets")
-				
+
                 self.assets = assets
                 self.previewView?.reloadData()
             }
-			
-			if UI_USER_INTERFACE_IDIOM() == .Pad {
-				pickerController.modalPresentationStyle = .FormSheet;
+
+            if UI_USER_INTERFACE_IDIOM() == .Pad {
+                pickerController.modalPresentationStyle = .FormSheet;
 			}
 
             self.presentViewController(pickerController, animated: true) {}
@@ -87,13 +100,13 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
     
     struct Demo {
         static let titles = [
-            ["Pick All", "Pick photos only", "Pick videos only", "Pick All (only photos or videos)"],
+            ["Pick All", "Pick photos only", "Pick videos only", "Pick All (only photos or videos)", "Pick All (reset selection)"],
             ["Take a picture"],
             ["Hides camera"],
 			["Allows landscape"],
 			["Single select"]
         ]
-        static let types: [DKImagePickerControllerAssetType] = [.AllAssets, .AllPhotos, .AllVideos, .AllAssets]
+        static let types: [DKImagePickerControllerAssetType] = [.AllAssets, .AllPhotos, .AllVideos, .AllAssets, .AllAssets]
     }
     
     func numberOfSectionsInTableView(tableView: UITableView) -> Int {
@@ -121,13 +134,14 @@ class ViewController: UIViewController, UITableViewDataSource, UITableViewDelega
 			(indexPath.section == 2 ? .Photo : [.Camera, .Photo])
 		let allowsLandscape = indexPath.section == 3
 		let singleSelect = indexPath.section == 4
-		
+		let shouldDeselect = indexPath.section == 0 && indexPath.row == 4
 		showImagePickerWithAssetType(
 			assetType,
 			allowMultipleType: allowMultipleType,
 			sourceType: sourceType,
 			allowsLandscape: allowsLandscape,
-			singleSelect: singleSelect
+			singleSelect: singleSelect,
+            shouldDeselect: shouldDeselect
 		)
 	}
 	


### PR DESCRIPTION
Added possibility to deselect assets when showing picker multiple times.

If DKImagePickerController is used in some VC multiple time it might be useful sometimes to clear selection on each use. Currently, if I want to show clean selection I'd need to create new instance of image picker, which is not memory efficient.

Use case:
There is VC to add new images with some custom titles, etc to 'posts feed'. User can choose maximum X posts, but he can display picker multiple time. As each time all selected photos are used in application VC, picker should show no selection each time it's shown.