### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It's a Facebook style Image Picker Controller by Swift. It uses [DKCamera][DKCam
 
 ## Installation
 #### iOS 8 and newer
-DKImagePickerController is available on Cocoapods. Simply add the following line to your podfile:
+DKImagePickerController is available on CocoaPods. Simply add the following line to your podfile:
 
 ```ruby
 # For latest release in cocoapods


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
