### PR TITLE
Allow background & camera icon customization, default to 4:3 ratio, don't dismiss picker after taking a photo, and format the code

### DIFF
--- a/DKCamera/DKCamera.swift
+++ b/DKCamera/DKCamera.swift
@@ -59,7 +59,9 @@ public class DKCamera: UIViewController {
 	public class func isAvailable() -> Bool {
 		return UIImagePickerController.isSourceTypeAvailable(.Camera)
 	}
-	
+
+    public var use16to9Ratio = false
+
 	/// Determines whether or not the rotation is enabled.
 	public var allowsRotate = false
 	
@@ -369,7 +371,10 @@ public class DKCamera: UIViewController {
 	// MARK: - Capture Session
 	
 	public func beginSession() {
-		self.captureSession.sessionPreset = AVCaptureSessionPresetHigh
+        self.captureSession.sessionPreset = AVCaptureSessionPresetPhoto
+        if use16to9Ratio {
+            self.captureSession.sessionPreset = AVCaptureSessionPresetHigh
+        }
 		
 		self.setupCurrentDevice()
 		

--- a/DKImagePickerController/DKImagePickerController.swift
+++ b/DKImagePickerController/DKImagePickerController.swift
@@ -232,11 +232,11 @@ public class DKImagePickerController: UINavigationController {
                         if success {
                             if let newAsset = PHAsset.fetchAssetsWithLocalIdentifiers([newImageIdentifier], options: nil).firstObject as? PHAsset {
                                 self.dismissViewControllerAnimated(true, completion: nil)
-                                self.selectedImage(DKAsset(originalAsset: newAsset), needsToDismiss: false)
+                                self.selectedImage(DKAsset(originalAsset: newAsset), needsToDismiss: true)
                             }
                         } else {
                             self.dismissViewControllerAnimated(true, completion: nil)
-                            self.selectedImage(DKAsset(image: image), needsToDismiss: false)
+                            self.selectedImage(DKAsset(image: image), needsToDismiss: true)
                         }
                     })
             })

--- a/DKImagePickerController/DKImagePickerController.swift
+++ b/DKImagePickerController/DKImagePickerController.swift
@@ -44,6 +44,7 @@ public struct DKImagePickerControllerSourceType : OptionSetType {
 */
 public class DKImagePickerController: UINavigationController {
 
+    public var use16to9Ratio = false
     public var cameraIcon: UIImage?
     public var overrideBackgroundColor: UIColor?
 
@@ -214,6 +215,7 @@ public class DKImagePickerController: UINavigationController {
 
     private func createCamera() -> DKCamera {
         let camera = DKCamera()
+        camera.use16to9Ratio = self.use16to9Ratio
 
         camera.didCancel = {[unowned camera] () -> Void in
             camera.dismissViewControllerAnimated(true, completion: nil)
@@ -230,11 +232,11 @@ public class DKImagePickerController: UINavigationController {
                         if success {
                             if let newAsset = PHAsset.fetchAssetsWithLocalIdentifiers([newImageIdentifier], options: nil).firstObject as? PHAsset {
                                 self.dismissViewControllerAnimated(true, completion: nil)
-                                self.selectedImage(DKAsset(originalAsset: newAsset), needsToDismiss: true)
+                                self.selectedImage(DKAsset(originalAsset: newAsset), needsToDismiss: false)
                             }
                         } else {
                             self.dismissViewControllerAnimated(true, completion: nil)
-                            self.selectedImage(DKAsset(image: image), needsToDismiss: true)
+                            self.selectedImage(DKAsset(image: image), needsToDismiss: false)
                         }
                     })
             })

--- a/DKImagePickerController/DKImagePickerController.swift
+++ b/DKImagePickerController/DKImagePickerController.swift
@@ -43,12 +43,15 @@ public struct DKImagePickerControllerSourceType : OptionSetType {
  * The `DKImagePickerController` class offers the all public APIs which will affect the UI.
  */
 public class DKImagePickerController: UINavigationController {
-    
-    /// Forces selection of tapped image immediatly.
-	public var singleSelect = false
-		
-    /// The maximum count of assets which the user will be able to select.
-    public var maxSelectableCount = 999
+
+  public var cameraIcon: UIImage?
+  public var overrideBackgroundColor: UIColor?
+
+  /// Forces selection of tapped image immediatly.
+  public var singleSelect = false
+
+  /// The maximum count of assets which the user will be able to select.
+  public var maxSelectableCount = 999
 	
 	/// Set the defaultAssetGroup to specify which album is the default asset group.
 	public var defaultAssetGroup: PHAssetCollectionSubtype?
@@ -167,6 +170,8 @@ public class DKImagePickerController: UINavigationController {
 				self.setViewControllers([self.createCamera()], animated: false)
 			} else {
 				let rootVC = DKAssetGroupDetailVC()
+        rootVC.cameraIcon = cameraIcon
+        rootVC.overrideBackgroundColor = overrideBackgroundColor
 				self.updateCancelButtonForVC(rootVC)
 				self.setViewControllers([rootVC], animated: false)
 				rootVC.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: self.doneButton)

--- a/DKImagePickerController/DKImagePickerController.swift
+++ b/DKImagePickerController/DKImagePickerController.swift
@@ -17,24 +17,24 @@ import Photos
 @objc
 public enum DKImagePickerControllerAssetType : Int {
 
-  case AllPhotos, AllVideos, AllAssets
+    case AllPhotos, AllVideos, AllAssets
 }
 
 public struct DKImagePickerControllerSourceType : OptionSetType {
 
-  private var value: UInt = 0
-  init(_ value: UInt) { self.value = value }
-  // MARK: _RawOptionSetType
-  public init(rawValue value: UInt) { self.value = value }
-  // MARK: NilLiteralConvertible
-  public init(nilLiteral: ()) { self.value = 0 }
-  // MARK: RawRepresentable
-  public var rawValue: UInt { return self.value }
-  // MARK: BitwiseOperationsType
-  public static var allZeros: DKImagePickerControllerSourceType { return self.init(0) }
+    private var value: UInt = 0
+    init(_ value: UInt) { self.value = value }
+    // MARK: _RawOptionSetType
+    public init(rawValue value: UInt) { self.value = value }
+    // MARK: NilLiteralConvertible
+    public init(nilLiteral: ()) { self.value = 0 }
+    // MARK: RawRepresentable
+    public var rawValue: UInt { return self.value }
+    // MARK: BitwiseOperationsType
+    public static var allZeros: DKImagePickerControllerSourceType { return self.init(0) }
 
-  public static var Camera: DKImagePickerControllerSourceType { return self.init(1 << 0) }
-  public static var Photo: DKImagePickerControllerSourceType { return self.init(1 << 1) }
+    public static var Camera: DKImagePickerControllerSourceType { return self.init(1 << 0) }
+    public static var Photo: DKImagePickerControllerSourceType { return self.init(1 << 1) }
 }
 
 // MARK: - Public DKImagePickerController
@@ -44,287 +44,287 @@ public struct DKImagePickerControllerSourceType : OptionSetType {
 */
 public class DKImagePickerController: UINavigationController {
 
-  public var cameraIcon: UIImage?
-  public var overrideBackgroundColor: UIColor?
+    public var cameraIcon: UIImage?
+    public var overrideBackgroundColor: UIColor?
 
-  /// Forces selection of tapped image immediatly.
-  public var singleSelect = false
+    /// Forces selection of tapped image immediatly.
+    public var singleSelect = false
 
-  /// The maximum count of assets which the user will be able to select.
-  public var maxSelectableCount = 999
+    /// The maximum count of assets which the user will be able to select.
+    public var maxSelectableCount = 999
 
-  /// Set the defaultAssetGroup to specify which album is the default asset group.
-  public var defaultAssetGroup: PHAssetCollectionSubtype?
+    /// Set the defaultAssetGroup to specify which album is the default asset group.
+    public var defaultAssetGroup: PHAssetCollectionSubtype?
 
-  /// The types of PHAssetCollection to display in the picker.
-  public var assetGroupTypes: [PHAssetCollectionSubtype] = [
-    .SmartAlbumUserLibrary,
-    .SmartAlbumFavorites,
-    .AlbumRegular
-    ] {
-    didSet {
-      getImageManager().groupDataManager.assetGroupTypes = self.assetGroupTypes
-    }
-  }
-
-  /// Set the showsEmptyAlbums to specify whether or not the empty albums is shown in the picker.
-  public var showsEmptyAlbums = true {
-    didSet {
-      getImageManager().groupDataManager.showsEmptyAlbums = self.showsEmptyAlbums
-    }
-  }
-
-  /// The type of picker interface to be displayed by the controller.
-  public var assetType: DKImagePickerControllerAssetType = .AllAssets {
-    didSet {
-      getImageManager().groupDataManager.assetFetchOptions = self.createAssetFetchOptions()
-    }
-  }
-
-  /// If sourceType is Camera will cause the assetType & maxSelectableCount & allowMultipleTypes & defaultSelectedAssets to be ignored.
-  public var sourceType: DKImagePickerControllerSourceType = [.Camera, .Photo]
-
-  /// Whether allows to select photos and videos at the same time.
-  public var allowMultipleTypes = true
-
-  /// If YES, and the requested image is not stored on the local device, the Picker downloads the image from iCloud.
-  public var autoDownloadWhenAssetIsInCloud = true {
-    didSet {
-      getImageManager().autoDownloadWhenAssetIsInCloud = self.autoDownloadWhenAssetIsInCloud
-    }
-  }
-
-  /// Determines whether or not the rotation is enabled.
-  public var allowsLandscape = false
-
-  /// The callback block is executed when user pressed the cancel button.
-  public var didCancel: (() -> Void)?
-  public var showsCancelButton = false {
-    didSet {
-      if let rootVC =  self.viewControllers.first {
-        self.updateCancelButtonForVC(rootVC)
-      }
-    }
-  }
-
-  /// The callback block is executed when user pressed the select button.
-  public var didSelectAssets: ((assets: [DKAsset]) -> Void)?
-
-  /// It will have selected the specific assets.
-  public var defaultSelectedAssets: [DKAsset]? {
-    didSet {
-      self.selectedAssets = self.defaultSelectedAssets ?? []
-
-      if let rootVC = self.viewControllers.first as? DKAssetGroupDetailVC {
-        rootVC.collectionView?.reloadData()
-      }
-      self.updateDoneButtonTitle()
-    }
-  }
-
-  internal var selectedAssets = [DKAsset]()
-
-  private lazy var doneButton: UIButton = {
-    let button = UIButton(type: UIButtonType.Custom)
-    button.setTitleColor(UINavigationBar.appearance().tintColor ?? self.navigationBar.tintColor, forState: UIControlState.Normal)
-    button.addTarget(self, action: "done", forControlEvents: UIControlEvents.TouchUpInside)
-
-    return button
-  }()
-
-  public convenience init() {
-    let rootVC = UIViewController()
-    self.init(rootViewController: rootVC)
-
-    self.preferredContentSize = CGSize(width: 680, height: 600)
-
-    rootVC.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: self.doneButton)
-    rootVC.navigationItem.hidesBackButton = true
-
-    getImageManager().groupDataManager.assetGroupTypes = self.assetGroupTypes
-    getImageManager().groupDataManager.assetFetchOptions = self.createAssetFetchOptions()
-    getImageManager().groupDataManager.showsEmptyAlbums = self.showsEmptyAlbums
-    getImageManager().autoDownloadWhenAssetIsInCloud = self.autoDownloadWhenAssetIsInCloud
-
-    self.updateDoneButtonTitle()
-  }
-
-  deinit {
-    NSNotificationCenter.defaultCenter().removeObserver(self)
-    getImageManager().invalidate()
-  }
-
-  override public func viewDidLoad() {
-    super.viewDidLoad()
-  }
-
-  private var hasInitialized = false
-  override public func viewWillAppear(animated: Bool) {
-    super.viewWillAppear(animated)
-
-    if !hasInitialized {
-      hasInitialized = true
-
-      if !self.sourceType.contains(.Photo) {
-        self.navigationBarHidden = true
-        self.setViewControllers([self.createCamera()], animated: false)
-      } else {
-        let rootVC = DKAssetGroupDetailVC()
-        rootVC.cameraIcon = cameraIcon
-        rootVC.overrideBackgroundColor = overrideBackgroundColor
-        self.updateCancelButtonForVC(rootVC)
-        self.setViewControllers([rootVC], animated: false)
-        rootVC.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: self.doneButton)
-      }
-    }
-  }
-
-  private lazy var assetFetchOptions: PHFetchOptions = {
-    let assetFetchOptions = PHFetchOptions()
-    assetFetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
-    return assetFetchOptions
-  }()
-
-  private func createAssetFetchOptions() -> PHFetchOptions? {
-    if self.assetType != .AllAssets {
-      self.assetFetchOptions.predicate = NSPredicate(format: "mediaType == %d",
-        self.assetType == .AllPhotos ? PHAssetMediaType.Image.rawValue : PHAssetMediaType.Video.rawValue)
-    }
-    return self.assetFetchOptions
-  }
-
-  private func updateCancelButtonForVC(vc: UIViewController) {
-    if self.showsCancelButton {
-      vc.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Cancel,
-        target: self,
-        action: "dismiss")
-    } else {
-      vc.navigationItem.leftBarButtonItem = nil
-    }
-  }
-
-  private func updateDoneButtonTitle() {
-    if self.selectedAssets.count > 0 {
-      self.doneButton.setTitle(DKImageLocalizedStringWithKey("select") + "(\(selectedAssets.count))", forState: UIControlState.Normal)
-    } else {
-      self.doneButton.setTitle(DKImageLocalizedStringWithKey("done"), forState: UIControlState.Normal)
-    }
-    self.doneButton.sizeToFit()
-  }
-
-  private func createCamera() -> DKCamera {
-    let camera = DKCamera()
-
-    camera.didCancel = {[unowned camera] () -> Void in
-      camera.dismissViewControllerAnimated(true, completion: nil)
+    /// The types of PHAssetCollection to display in the picker.
+    public var assetGroupTypes: [PHAssetCollectionSubtype] = [
+        .SmartAlbumUserLibrary,
+        .SmartAlbumFavorites,
+        .AlbumRegular
+        ] {
+        didSet {
+            getImageManager().groupDataManager.assetGroupTypes = self.assetGroupTypes
+        }
     }
 
-    camera.didFinishCapturingImage = { [unowned self] (image) in
-      var newImageIdentifier: String!
-      PHPhotoLibrary.sharedPhotoLibrary().performChanges(
-        { () in
-          let assetRequest = PHAssetChangeRequest.creationRequestForAssetFromImage(image)
-          newImageIdentifier = assetRequest.placeholderForCreatedAsset!.localIdentifier
-        }, completionHandler: { (success, error) -> Void in
-          dispatch_async(dispatch_get_main_queue(), { () -> Void in
-            if success {
-              if let newAsset = PHAsset.fetchAssetsWithLocalIdentifiers([newImageIdentifier], options: nil).firstObject as? PHAsset {
-                self.dismissViewControllerAnimated(true, completion: nil)
-                self.selectedImage(DKAsset(originalAsset: newAsset), needsToDismiss: true)
-              }
-            } else {
-              self.dismissViewControllerAnimated(true, completion: nil)
-              self.selectedImage(DKAsset(image: image), needsToDismiss: true)
+    /// Set the showsEmptyAlbums to specify whether or not the empty albums is shown in the picker.
+    public var showsEmptyAlbums = true {
+        didSet {
+            getImageManager().groupDataManager.showsEmptyAlbums = self.showsEmptyAlbums
+        }
+    }
+
+    /// The type of picker interface to be displayed by the controller.
+    public var assetType: DKImagePickerControllerAssetType = .AllAssets {
+        didSet {
+            getImageManager().groupDataManager.assetFetchOptions = self.createAssetFetchOptions()
+        }
+    }
+
+    /// If sourceType is Camera will cause the assetType & maxSelectableCount & allowMultipleTypes & defaultSelectedAssets to be ignored.
+    public var sourceType: DKImagePickerControllerSourceType = [.Camera, .Photo]
+
+    /// Whether allows to select photos and videos at the same time.
+    public var allowMultipleTypes = true
+
+    /// If YES, and the requested image is not stored on the local device, the Picker downloads the image from iCloud.
+    public var autoDownloadWhenAssetIsInCloud = true {
+        didSet {
+            getImageManager().autoDownloadWhenAssetIsInCloud = self.autoDownloadWhenAssetIsInCloud
+        }
+    }
+
+    /// Determines whether or not the rotation is enabled.
+    public var allowsLandscape = false
+
+    /// The callback block is executed when user pressed the cancel button.
+    public var didCancel: (() -> Void)?
+    public var showsCancelButton = false {
+        didSet {
+            if let rootVC =  self.viewControllers.first {
+                self.updateCancelButtonForVC(rootVC)
             }
-          })
-      })
-    }
-    self.checkCameraPermission(camera)
-
-    return camera
-  }
-
-  internal func checkCameraPermission(camera: DKCamera) {
-    func cameraDenied() {
-      dispatch_async(dispatch_get_main_queue()) {
-        let permissionView = DKPermissionView.permissionView(.Camera)
-        camera.cameraOverlayView = permissionView
-      }
+        }
     }
 
-    func setup() {
-      camera.cameraOverlayView = nil
+    /// The callback block is executed when user pressed the select button.
+    public var didSelectAssets: ((assets: [DKAsset]) -> Void)?
+
+    /// It will have selected the specific assets.
+    public var defaultSelectedAssets: [DKAsset]? {
+        didSet {
+            self.selectedAssets = self.defaultSelectedAssets ?? []
+
+            if let rootVC = self.viewControllers.first as? DKAssetGroupDetailVC {
+                rootVC.collectionView?.reloadData()
+            }
+            self.updateDoneButtonTitle()
+        }
     }
 
-    DKCamera.checkCameraPermission { granted in
-      granted ? setup() : cameraDenied()
+    internal var selectedAssets = [DKAsset]()
+
+    private lazy var doneButton: UIButton = {
+        let button = UIButton(type: UIButtonType.Custom)
+        button.setTitleColor(UINavigationBar.appearance().tintColor ?? self.navigationBar.tintColor, forState: UIControlState.Normal)
+        button.addTarget(self, action: "done", forControlEvents: UIControlEvents.TouchUpInside)
+
+        return button
+    }()
+
+    public convenience init() {
+        let rootVC = UIViewController()
+        self.init(rootViewController: rootVC)
+
+        self.preferredContentSize = CGSize(width: 680, height: 600)
+
+        rootVC.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: self.doneButton)
+        rootVC.navigationItem.hidesBackButton = true
+
+        getImageManager().groupDataManager.assetGroupTypes = self.assetGroupTypes
+        getImageManager().groupDataManager.assetFetchOptions = self.createAssetFetchOptions()
+        getImageManager().groupDataManager.showsEmptyAlbums = self.showsEmptyAlbums
+        getImageManager().autoDownloadWhenAssetIsInCloud = self.autoDownloadWhenAssetIsInCloud
+
+        self.updateDoneButtonTitle()
     }
-  }
 
-  internal func presentCamera() {
-    self.presentViewController(self.createCamera(), animated: true, completion: nil)
-  }
-
-  internal func dismiss() {
-    self.dismissViewControllerAnimated(true, completion: nil)
-    self.didCancel?()
-  }
-
-  internal func done() {
-    self.dismissViewControllerAnimated(true, completion: nil)
-    self.didSelectAssets?(assets: self.selectedAssets)
-  }
-
-  // MARK: - Selection Image
-
-  internal func selectedImage(asset: DKAsset) {
-    self.selectedImage(asset, needsToDismiss: false)
-  }
-
-  internal func selectedImage(asset: DKAsset, needsToDismiss: Bool) {
-    selectedAssets.append(asset)
-    if needsToDismiss {
-      self.done()
-    } else if self.singleSelect {
-      self.done()
-    } else {
-      updateDoneButtonTitle()
+    deinit {
+        NSNotificationCenter.defaultCenter().removeObserver(self)
+        getImageManager().invalidate()
     }
-  }
 
-  internal func unselectedImage(asset: DKAsset) {
-    selectedAssets.removeAtIndex(selectedAssets.indexOf(asset)!)
-    updateDoneButtonTitle()
-  }
-
-  // MARK: - Handles Orientation
-
-  public override func shouldAutorotate() -> Bool {
-    return self.allowsLandscape ? true : false
-  }
-
-  public override func supportedInterfaceOrientations() -> UIInterfaceOrientationMask {
-    if self.allowsLandscape {
-      return super.supportedInterfaceOrientations()
-    } else {
-      return UIInterfaceOrientationMask.Portrait
+    override public func viewDidLoad() {
+        super.viewDidLoad()
     }
-  }
+
+    private var hasInitialized = false
+    override public func viewWillAppear(animated: Bool) {
+        super.viewWillAppear(animated)
+
+        if !hasInitialized {
+            hasInitialized = true
+
+            if !self.sourceType.contains(.Photo) {
+                self.navigationBarHidden = true
+                self.setViewControllers([self.createCamera()], animated: false)
+            } else {
+                let rootVC = DKAssetGroupDetailVC()
+                rootVC.cameraIcon = cameraIcon
+                rootVC.overrideBackgroundColor = overrideBackgroundColor
+                self.updateCancelButtonForVC(rootVC)
+                self.setViewControllers([rootVC], animated: false)
+                rootVC.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: self.doneButton)
+            }
+        }
+    }
+
+    private lazy var assetFetchOptions: PHFetchOptions = {
+        let assetFetchOptions = PHFetchOptions()
+        assetFetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+        return assetFetchOptions
+    }()
+
+    private func createAssetFetchOptions() -> PHFetchOptions? {
+        if self.assetType != .AllAssets {
+            self.assetFetchOptions.predicate = NSPredicate(format: "mediaType == %d",
+                self.assetType == .AllPhotos ? PHAssetMediaType.Image.rawValue : PHAssetMediaType.Video.rawValue)
+        }
+        return self.assetFetchOptions
+    }
+
+    private func updateCancelButtonForVC(vc: UIViewController) {
+        if self.showsCancelButton {
+            vc.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Cancel,
+                target: self,
+                action: "dismiss")
+        } else {
+            vc.navigationItem.leftBarButtonItem = nil
+        }
+    }
+
+    private func updateDoneButtonTitle() {
+        if self.selectedAssets.count > 0 {
+            self.doneButton.setTitle(DKImageLocalizedStringWithKey("select") + "(\(selectedAssets.count))", forState: UIControlState.Normal)
+        } else {
+            self.doneButton.setTitle(DKImageLocalizedStringWithKey("done"), forState: UIControlState.Normal)
+        }
+        self.doneButton.sizeToFit()
+    }
+
+    private func createCamera() -> DKCamera {
+        let camera = DKCamera()
+
+        camera.didCancel = {[unowned camera] () -> Void in
+            camera.dismissViewControllerAnimated(true, completion: nil)
+        }
+
+        camera.didFinishCapturingImage = { [unowned self] (image) in
+            var newImageIdentifier: String!
+            PHPhotoLibrary.sharedPhotoLibrary().performChanges(
+                { () in
+                    let assetRequest = PHAssetChangeRequest.creationRequestForAssetFromImage(image)
+                    newImageIdentifier = assetRequest.placeholderForCreatedAsset!.localIdentifier
+                }, completionHandler: { (success, error) -> Void in
+                    dispatch_async(dispatch_get_main_queue(), { () -> Void in
+                        if success {
+                            if let newAsset = PHAsset.fetchAssetsWithLocalIdentifiers([newImageIdentifier], options: nil).firstObject as? PHAsset {
+                                self.dismissViewControllerAnimated(true, completion: nil)
+                                self.selectedImage(DKAsset(originalAsset: newAsset), needsToDismiss: true)
+                            }
+                        } else {
+                            self.dismissViewControllerAnimated(true, completion: nil)
+                            self.selectedImage(DKAsset(image: image), needsToDismiss: true)
+                        }
+                    })
+            })
+        }
+        self.checkCameraPermission(camera)
+
+        return camera
+    }
+
+    internal func checkCameraPermission(camera: DKCamera) {
+        func cameraDenied() {
+            dispatch_async(dispatch_get_main_queue()) {
+                let permissionView = DKPermissionView.permissionView(.Camera)
+                camera.cameraOverlayView = permissionView
+            }
+        }
+
+        func setup() {
+            camera.cameraOverlayView = nil
+        }
+
+        DKCamera.checkCameraPermission { granted in
+            granted ? setup() : cameraDenied()
+        }
+    }
+
+    internal func presentCamera() {
+        self.presentViewController(self.createCamera(), animated: true, completion: nil)
+    }
+
+    internal func dismiss() {
+        self.dismissViewControllerAnimated(true, completion: nil)
+        self.didCancel?()
+    }
+
+    internal func done() {
+        self.dismissViewControllerAnimated(true, completion: nil)
+        self.didSelectAssets?(assets: self.selectedAssets)
+    }
+
+    // MARK: - Selection Image
+
+    internal func selectedImage(asset: DKAsset) {
+        self.selectedImage(asset, needsToDismiss: false)
+    }
+    
+    internal func selectedImage(asset: DKAsset, needsToDismiss: Bool) {
+        selectedAssets.append(asset)
+        if needsToDismiss {
+            self.done()
+        } else if self.singleSelect {
+            self.done()
+        } else {
+            updateDoneButtonTitle()
+        }
+    }
+    
+    internal func unselectedImage(asset: DKAsset) {
+        selectedAssets.removeAtIndex(selectedAssets.indexOf(asset)!)
+        updateDoneButtonTitle()
+    }
+    
+    // MARK: - Handles Orientation
+    
+    public override func shouldAutorotate() -> Bool {
+        return self.allowsLandscape ? true : false
+    }
+    
+    public override func supportedInterfaceOrientations() -> UIInterfaceOrientationMask {
+        if self.allowsLandscape {
+            return super.supportedInterfaceOrientations()
+        } else {
+            return UIInterfaceOrientationMask.Portrait
+        }
+    }
 }
 
 // MARK: - Utilities
 
 internal extension UIViewController {
-
-  var imagePickerController: DKImagePickerController? {
-    get {
-      let nav = self.navigationController
-      if nav is DKImagePickerController {
-        return nav as? DKImagePickerController
-      } else {
-        return nil
-      }
+    
+    var imagePickerController: DKImagePickerController? {
+        get {
+            let nav = self.navigationController
+            if nav is DKImagePickerController {
+                return nav as? DKImagePickerController
+            } else {
+                return nil
+            }
+        }
     }
-  }
-  
+    
 }

--- a/DKImagePickerController/DKImagePickerController.swift
+++ b/DKImagePickerController/DKImagePickerController.swift
@@ -10,38 +10,38 @@ import UIKit
 import Photos
 
 /**
-* allPhotos: Get all photos assets in the assets group.
-* allVideos: Get all video assets in the assets group.
-* allAssets: Get all assets in the group.
-*/
+ * allPhotos: Get all photos assets in the assets group.
+ * allVideos: Get all video assets in the assets group.
+ * allAssets: Get all assets in the group.
+ */
 @objc
 public enum DKImagePickerControllerAssetType : Int {
-	
-	case AllPhotos, AllVideos, AllAssets
+
+  case AllPhotos, AllVideos, AllAssets
 }
 
 public struct DKImagePickerControllerSourceType : OptionSetType {
-    
-    private var value: UInt = 0
-    init(_ value: UInt) { self.value = value }
-    // MARK: _RawOptionSetType
-    public init(rawValue value: UInt) { self.value = value }
-    // MARK: NilLiteralConvertible
-    public init(nilLiteral: ()) { self.value = 0 }
-    // MARK: RawRepresentable
-    public var rawValue: UInt { return self.value }
-    // MARK: BitwiseOperationsType
-    public static var allZeros: DKImagePickerControllerSourceType { return self.init(0) }
-    
-    public static var Camera: DKImagePickerControllerSourceType { return self.init(1 << 0) }
-    public static var Photo: DKImagePickerControllerSourceType { return self.init(1 << 1) }
+
+  private var value: UInt = 0
+  init(_ value: UInt) { self.value = value }
+  // MARK: _RawOptionSetType
+  public init(rawValue value: UInt) { self.value = value }
+  // MARK: NilLiteralConvertible
+  public init(nilLiteral: ()) { self.value = 0 }
+  // MARK: RawRepresentable
+  public var rawValue: UInt { return self.value }
+  // MARK: BitwiseOperationsType
+  public static var allZeros: DKImagePickerControllerSourceType { return self.init(0) }
+
+  public static var Camera: DKImagePickerControllerSourceType { return self.init(1 << 0) }
+  public static var Photo: DKImagePickerControllerSourceType { return self.init(1 << 1) }
 }
 
 // MARK: - Public DKImagePickerController
 
 /**
- * The `DKImagePickerController` class offers the all public APIs which will affect the UI.
- */
+* The `DKImagePickerController` class offers the all public APIs which will affect the UI.
+*/
 public class DKImagePickerController: UINavigationController {
 
   public var cameraIcon: UIImage?
@@ -52,279 +52,279 @@ public class DKImagePickerController: UINavigationController {
 
   /// The maximum count of assets which the user will be able to select.
   public var maxSelectableCount = 999
-	
-	/// Set the defaultAssetGroup to specify which album is the default asset group.
-	public var defaultAssetGroup: PHAssetCollectionSubtype?
-	
-	/// The types of PHAssetCollection to display in the picker.
-	public var assetGroupTypes: [PHAssetCollectionSubtype] = [
-		.SmartAlbumUserLibrary,
-		.SmartAlbumFavorites,
-		.AlbumRegular
-		] {
-		didSet {
-			getImageManager().groupDataManager.assetGroupTypes = self.assetGroupTypes
-		}
-	}
-	
-	/// Set the showsEmptyAlbums to specify whether or not the empty albums is shown in the picker.
-	public var showsEmptyAlbums = true {
-		didSet {
-			getImageManager().groupDataManager.showsEmptyAlbums = self.showsEmptyAlbums
-		}
-	}
-	
-	/// The type of picker interface to be displayed by the controller.
-	public var assetType: DKImagePickerControllerAssetType = .AllAssets {
-		didSet {
-			getImageManager().groupDataManager.assetFetchOptions = self.createAssetFetchOptions()
-		}
-	}
-	
-    /// If sourceType is Camera will cause the assetType & maxSelectableCount & allowMultipleTypes & defaultSelectedAssets to be ignored.
-    public var sourceType: DKImagePickerControllerSourceType = [.Camera, .Photo]
-    
-    /// Whether allows to select photos and videos at the same time.
-    public var allowMultipleTypes = true
-	
-	/// If YES, and the requested image is not stored on the local device, the Picker downloads the image from iCloud.
-	public var autoDownloadWhenAssetIsInCloud = true {
-		didSet {
-			getImageManager().autoDownloadWhenAssetIsInCloud = self.autoDownloadWhenAssetIsInCloud
-		}
-	}
-	
-	/// Determines whether or not the rotation is enabled.
-	public var allowsLandscape = false
-	
-	/// The callback block is executed when user pressed the cancel button.
-	public var didCancel: (() -> Void)?
-	public var showsCancelButton = false {
-		didSet {
-			if let rootVC =  self.viewControllers.first {
-				self.updateCancelButtonForVC(rootVC)
-			}
-		}
-	}
-	
-    /// The callback block is executed when user pressed the select button.
-    public var didSelectAssets: ((assets: [DKAsset]) -> Void)?
-	
-    /// It will have selected the specific assets.
-    public var defaultSelectedAssets: [DKAsset]? {
-        didSet {
-			self.selectedAssets = self.defaultSelectedAssets ?? []
-			
-			if let rootVC = self.viewControllers.first as? DKAssetGroupDetailVC {
-				rootVC.collectionView?.reloadData()
-			}
-			self.updateDoneButtonTitle()
-        }
+
+  /// Set the defaultAssetGroup to specify which album is the default asset group.
+  public var defaultAssetGroup: PHAssetCollectionSubtype?
+
+  /// The types of PHAssetCollection to display in the picker.
+  public var assetGroupTypes: [PHAssetCollectionSubtype] = [
+    .SmartAlbumUserLibrary,
+    .SmartAlbumFavorites,
+    .AlbumRegular
+    ] {
+    didSet {
+      getImageManager().groupDataManager.assetGroupTypes = self.assetGroupTypes
     }
-    
-    internal var selectedAssets = [DKAsset]()
-    
-    private lazy var doneButton: UIButton = {
-        let button = UIButton(type: UIButtonType.Custom)
-		button.setTitleColor(UINavigationBar.appearance().tintColor ?? self.navigationBar.tintColor, forState: UIControlState.Normal)
-        button.addTarget(self, action: "done", forControlEvents: UIControlEvents.TouchUpInside)
-      
-        return button
-    }()
-    
-    public convenience init() {
-		let rootVC = UIViewController()
-        self.init(rootViewController: rootVC)
-		
-		self.preferredContentSize = CGSize(width: 680, height: 600)
-		
-        rootVC.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: self.doneButton)
-        rootVC.navigationItem.hidesBackButton = true
-		
-		getImageManager().groupDataManager.assetGroupTypes = self.assetGroupTypes
-		getImageManager().groupDataManager.assetFetchOptions = self.createAssetFetchOptions()
-		getImageManager().groupDataManager.showsEmptyAlbums = self.showsEmptyAlbums
-		getImageManager().autoDownloadWhenAssetIsInCloud = self.autoDownloadWhenAssetIsInCloud
-		
-        self.updateDoneButtonTitle()
+  }
+
+  /// Set the showsEmptyAlbums to specify whether or not the empty albums is shown in the picker.
+  public var showsEmptyAlbums = true {
+    didSet {
+      getImageManager().groupDataManager.showsEmptyAlbums = self.showsEmptyAlbums
     }
-    
-    deinit {
-        NSNotificationCenter.defaultCenter().removeObserver(self)
-		getImageManager().invalidate()
+  }
+
+  /// The type of picker interface to be displayed by the controller.
+  public var assetType: DKImagePickerControllerAssetType = .AllAssets {
+    didSet {
+      getImageManager().groupDataManager.assetFetchOptions = self.createAssetFetchOptions()
     }
-    
-    override public func viewDidLoad() {
-        super.viewDidLoad()
+  }
+
+  /// If sourceType is Camera will cause the assetType & maxSelectableCount & allowMultipleTypes & defaultSelectedAssets to be ignored.
+  public var sourceType: DKImagePickerControllerSourceType = [.Camera, .Photo]
+
+  /// Whether allows to select photos and videos at the same time.
+  public var allowMultipleTypes = true
+
+  /// If YES, and the requested image is not stored on the local device, the Picker downloads the image from iCloud.
+  public var autoDownloadWhenAssetIsInCloud = true {
+    didSet {
+      getImageManager().autoDownloadWhenAssetIsInCloud = self.autoDownloadWhenAssetIsInCloud
     }
-	
-	private var hasInitialized = false
-	override public func viewWillAppear(animated: Bool) {
-		super.viewWillAppear(animated)
-		
-		if !hasInitialized {
-			hasInitialized = true
-			
-			if !self.sourceType.contains(.Photo) {
-				self.navigationBarHidden = true
-				self.setViewControllers([self.createCamera()], animated: false)
-			} else {
-				let rootVC = DKAssetGroupDetailVC()
+  }
+
+  /// Determines whether or not the rotation is enabled.
+  public var allowsLandscape = false
+
+  /// The callback block is executed when user pressed the cancel button.
+  public var didCancel: (() -> Void)?
+  public var showsCancelButton = false {
+    didSet {
+      if let rootVC =  self.viewControllers.first {
+        self.updateCancelButtonForVC(rootVC)
+      }
+    }
+  }
+
+  /// The callback block is executed when user pressed the select button.
+  public var didSelectAssets: ((assets: [DKAsset]) -> Void)?
+
+  /// It will have selected the specific assets.
+  public var defaultSelectedAssets: [DKAsset]? {
+    didSet {
+      self.selectedAssets = self.defaultSelectedAssets ?? []
+
+      if let rootVC = self.viewControllers.first as? DKAssetGroupDetailVC {
+        rootVC.collectionView?.reloadData()
+      }
+      self.updateDoneButtonTitle()
+    }
+  }
+
+  internal var selectedAssets = [DKAsset]()
+
+  private lazy var doneButton: UIButton = {
+    let button = UIButton(type: UIButtonType.Custom)
+    button.setTitleColor(UINavigationBar.appearance().tintColor ?? self.navigationBar.tintColor, forState: UIControlState.Normal)
+    button.addTarget(self, action: "done", forControlEvents: UIControlEvents.TouchUpInside)
+
+    return button
+  }()
+
+  public convenience init() {
+    let rootVC = UIViewController()
+    self.init(rootViewController: rootVC)
+
+    self.preferredContentSize = CGSize(width: 680, height: 600)
+
+    rootVC.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: self.doneButton)
+    rootVC.navigationItem.hidesBackButton = true
+
+    getImageManager().groupDataManager.assetGroupTypes = self.assetGroupTypes
+    getImageManager().groupDataManager.assetFetchOptions = self.createAssetFetchOptions()
+    getImageManager().groupDataManager.showsEmptyAlbums = self.showsEmptyAlbums
+    getImageManager().autoDownloadWhenAssetIsInCloud = self.autoDownloadWhenAssetIsInCloud
+
+    self.updateDoneButtonTitle()
+  }
+
+  deinit {
+    NSNotificationCenter.defaultCenter().removeObserver(self)
+    getImageManager().invalidate()
+  }
+
+  override public func viewDidLoad() {
+    super.viewDidLoad()
+  }
+
+  private var hasInitialized = false
+  override public func viewWillAppear(animated: Bool) {
+    super.viewWillAppear(animated)
+
+    if !hasInitialized {
+      hasInitialized = true
+
+      if !self.sourceType.contains(.Photo) {
+        self.navigationBarHidden = true
+        self.setViewControllers([self.createCamera()], animated: false)
+      } else {
+        let rootVC = DKAssetGroupDetailVC()
         rootVC.cameraIcon = cameraIcon
         rootVC.overrideBackgroundColor = overrideBackgroundColor
-				self.updateCancelButtonForVC(rootVC)
-				self.setViewControllers([rootVC], animated: false)
-				rootVC.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: self.doneButton)
-			}
-		}
-	}
-	
-	private lazy var assetFetchOptions: PHFetchOptions = {
-		let assetFetchOptions = PHFetchOptions()
-		assetFetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
-		return assetFetchOptions
-	}()
-	
-	private func createAssetFetchOptions() -> PHFetchOptions? {
-		if self.assetType != .AllAssets {
-			self.assetFetchOptions.predicate = NSPredicate(format: "mediaType == %d",
-				self.assetType == .AllPhotos ? PHAssetMediaType.Image.rawValue : PHAssetMediaType.Video.rawValue)
-		}
-		return self.assetFetchOptions
-	}
-	
-	private func updateCancelButtonForVC(vc: UIViewController) {
-		if self.showsCancelButton {
-			vc.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Cancel,
-				target: self,
-				action: "dismiss")
-		} else {
-			vc.navigationItem.leftBarButtonItem = nil
-		}
-	}
-	
-    private func updateDoneButtonTitle() {
-        if self.selectedAssets.count > 0 {
-            self.doneButton.setTitle(DKImageLocalizedStringWithKey("select") + "(\(selectedAssets.count))", forState: UIControlState.Normal)
-        } else {
-            self.doneButton.setTitle(DKImageLocalizedStringWithKey("done"), forState: UIControlState.Normal)
-        }
-        self.doneButton.sizeToFit()
+        self.updateCancelButtonForVC(rootVC)
+        self.setViewControllers([rootVC], animated: false)
+        rootVC.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: self.doneButton)
+      }
     }
-	
-	private func createCamera() -> DKCamera {
-		let camera = DKCamera()
-		
-		camera.didCancel = {[unowned camera] () -> Void in
-			camera.dismissViewControllerAnimated(true, completion: nil)
-		}
-		
-		camera.didFinishCapturingImage = { [unowned self] (image) in
-			var newImageIdentifier: String!
-			PHPhotoLibrary.sharedPhotoLibrary().performChanges(
-				{ () in
-					let assetRequest = PHAssetChangeRequest.creationRequestForAssetFromImage(image)
-					newImageIdentifier = assetRequest.placeholderForCreatedAsset!.localIdentifier
-				}, completionHandler: { (success, error) -> Void in
-					dispatch_async(dispatch_get_main_queue(), { () -> Void in
-						if success {
-							if let newAsset = PHAsset.fetchAssetsWithLocalIdentifiers([newImageIdentifier], options: nil).firstObject as? PHAsset {
-								self.dismissViewControllerAnimated(true, completion: nil)
-								self.selectedImage(DKAsset(originalAsset: newAsset), needsToDismiss: true)
-							}
-						} else {
-							self.dismissViewControllerAnimated(true, completion: nil)
-							self.selectedImage(DKAsset(image: image), needsToDismiss: true)
-						}
-					})
-			})
-		}
-		self.checkCameraPermission(camera)
-		
-		return camera
-	}
-	
-	internal func checkCameraPermission(camera: DKCamera) {
-		func cameraDenied() {
-			dispatch_async(dispatch_get_main_queue()) {
-				let permissionView = DKPermissionView.permissionView(.Camera)
-				camera.cameraOverlayView = permissionView
-			}
-		}
-		
-		func setup() {
-			camera.cameraOverlayView = nil
-		}
-		
-		DKCamera.checkCameraPermission { granted in
-			granted ? setup() : cameraDenied()
-		}
-	}
-	
-	internal func presentCamera() {
-		self.presentViewController(self.createCamera(), animated: true, completion: nil)
-	}
-	
-	internal func dismiss() {
-		self.dismissViewControllerAnimated(true, completion: nil)
-		self.didCancel?()
-	}
-	
-    internal func done() {
-        self.dismissViewControllerAnimated(true, completion: nil)
-        self.didSelectAssets?(assets: self.selectedAssets)
-    }
-    
-    // MARK: - Selection Image
-	
-	internal func selectedImage(asset: DKAsset) {
-		self.selectedImage(asset, needsToDismiss: false)
-	}
-	
-	internal func selectedImage(asset: DKAsset, needsToDismiss: Bool) {
-		selectedAssets.append(asset)
-		if needsToDismiss {
-			self.done()
-		} else if self.singleSelect {
-			self.done()
-		} else {
-			updateDoneButtonTitle()
-		}
-	}
-	
-	internal func unselectedImage(asset: DKAsset) {
-		selectedAssets.removeAtIndex(selectedAssets.indexOf(asset)!)
-		updateDoneButtonTitle()
-	}
-	
-    // MARK: - Handles Orientation
+  }
 
-    public override func shouldAutorotate() -> Bool {
-		return self.allowsLandscape ? true : false
+  private lazy var assetFetchOptions: PHFetchOptions = {
+    let assetFetchOptions = PHFetchOptions()
+    assetFetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
+    return assetFetchOptions
+  }()
+
+  private func createAssetFetchOptions() -> PHFetchOptions? {
+    if self.assetType != .AllAssets {
+      self.assetFetchOptions.predicate = NSPredicate(format: "mediaType == %d",
+        self.assetType == .AllPhotos ? PHAssetMediaType.Image.rawValue : PHAssetMediaType.Video.rawValue)
     }
-    
-    public override func supportedInterfaceOrientations() -> UIInterfaceOrientationMask {
-		if self.allowsLandscape {
-			return super.supportedInterfaceOrientations()
-		} else {
-			return UIInterfaceOrientationMask.Portrait
-		}
+    return self.assetFetchOptions
+  }
+
+  private func updateCancelButtonForVC(vc: UIViewController) {
+    if self.showsCancelButton {
+      vc.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .Cancel,
+        target: self,
+        action: "dismiss")
+    } else {
+      vc.navigationItem.leftBarButtonItem = nil
     }
+  }
+
+  private func updateDoneButtonTitle() {
+    if self.selectedAssets.count > 0 {
+      self.doneButton.setTitle(DKImageLocalizedStringWithKey("select") + "(\(selectedAssets.count))", forState: UIControlState.Normal)
+    } else {
+      self.doneButton.setTitle(DKImageLocalizedStringWithKey("done"), forState: UIControlState.Normal)
+    }
+    self.doneButton.sizeToFit()
+  }
+
+  private func createCamera() -> DKCamera {
+    let camera = DKCamera()
+
+    camera.didCancel = {[unowned camera] () -> Void in
+      camera.dismissViewControllerAnimated(true, completion: nil)
+    }
+
+    camera.didFinishCapturingImage = { [unowned self] (image) in
+      var newImageIdentifier: String!
+      PHPhotoLibrary.sharedPhotoLibrary().performChanges(
+        { () in
+          let assetRequest = PHAssetChangeRequest.creationRequestForAssetFromImage(image)
+          newImageIdentifier = assetRequest.placeholderForCreatedAsset!.localIdentifier
+        }, completionHandler: { (success, error) -> Void in
+          dispatch_async(dispatch_get_main_queue(), { () -> Void in
+            if success {
+              if let newAsset = PHAsset.fetchAssetsWithLocalIdentifiers([newImageIdentifier], options: nil).firstObject as? PHAsset {
+                self.dismissViewControllerAnimated(true, completion: nil)
+                self.selectedImage(DKAsset(originalAsset: newAsset), needsToDismiss: true)
+              }
+            } else {
+              self.dismissViewControllerAnimated(true, completion: nil)
+              self.selectedImage(DKAsset(image: image), needsToDismiss: true)
+            }
+          })
+      })
+    }
+    self.checkCameraPermission(camera)
+
+    return camera
+  }
+
+  internal func checkCameraPermission(camera: DKCamera) {
+    func cameraDenied() {
+      dispatch_async(dispatch_get_main_queue()) {
+        let permissionView = DKPermissionView.permissionView(.Camera)
+        camera.cameraOverlayView = permissionView
+      }
+    }
+
+    func setup() {
+      camera.cameraOverlayView = nil
+    }
+
+    DKCamera.checkCameraPermission { granted in
+      granted ? setup() : cameraDenied()
+    }
+  }
+
+  internal func presentCamera() {
+    self.presentViewController(self.createCamera(), animated: true, completion: nil)
+  }
+
+  internal func dismiss() {
+    self.dismissViewControllerAnimated(true, completion: nil)
+    self.didCancel?()
+  }
+
+  internal func done() {
+    self.dismissViewControllerAnimated(true, completion: nil)
+    self.didSelectAssets?(assets: self.selectedAssets)
+  }
+
+  // MARK: - Selection Image
+
+  internal func selectedImage(asset: DKAsset) {
+    self.selectedImage(asset, needsToDismiss: false)
+  }
+
+  internal func selectedImage(asset: DKAsset, needsToDismiss: Bool) {
+    selectedAssets.append(asset)
+    if needsToDismiss {
+      self.done()
+    } else if self.singleSelect {
+      self.done()
+    } else {
+      updateDoneButtonTitle()
+    }
+  }
+
+  internal func unselectedImage(asset: DKAsset) {
+    selectedAssets.removeAtIndex(selectedAssets.indexOf(asset)!)
+    updateDoneButtonTitle()
+  }
+
+  // MARK: - Handles Orientation
+
+  public override func shouldAutorotate() -> Bool {
+    return self.allowsLandscape ? true : false
+  }
+
+  public override func supportedInterfaceOrientations() -> UIInterfaceOrientationMask {
+    if self.allowsLandscape {
+      return super.supportedInterfaceOrientations()
+    } else {
+      return UIInterfaceOrientationMask.Portrait
+    }
+  }
 }
 
 // MARK: - Utilities
 
 internal extension UIViewController {
-    
-    var imagePickerController: DKImagePickerController? {
-        get {
-            let nav = self.navigationController
-            if nav is DKImagePickerController {
-                return nav as? DKImagePickerController
-            } else {
-                return nil
-            }
-        }
+
+  var imagePickerController: DKImagePickerController? {
+    get {
+      let nav = self.navigationController
+      if nav is DKImagePickerController {
+        return nav as? DKImagePickerController
+      } else {
+        return nil
+      }
     }
-    
+  }
+  
 }

--- a/DKImagePickerController/View/DKAssetGroupDetailVC.swift
+++ b/DKImagePickerController/View/DKAssetGroupDetailVC.swift
@@ -17,439 +17,439 @@ private let DKVideoAssetIdentifier = "DKVideoAssetIdentifier"
 // Show all images in the asset group
 internal class DKAssetGroupDetailVC: UICollectionViewController, DKGroupDataManagerObserver {
 
-  internal var cameraIcon: UIImage?
-  internal var overrideBackgroundColor: UIColor?
+    internal var cameraIcon: UIImage?
+    internal var overrideBackgroundColor: UIColor?
 
-  class DKImageCameraCell: UICollectionViewCell {
+    class DKImageCameraCell: UICollectionViewCell {
 
-    internal var cameraButton: UIButton!
-    var didCameraButtonClicked: (() -> Void)?
+        internal var cameraButton: UIButton!
+        var didCameraButtonClicked: (() -> Void)?
 
-    override init(frame: CGRect) {
-      super.init(frame: frame)
+        override init(frame: CGRect) {
+            super.init(frame: frame)
 
-      cameraButton = UIButton(frame: frame)
-      cameraButton.addTarget(self, action: "cameraButtonClicked", forControlEvents: .TouchUpInside)
-      cameraButton.setImage(DKImageResource.cameraImage(), forState: .Normal)
-      cameraButton.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
-      self.contentView.addSubview(cameraButton)
+            cameraButton = UIButton(frame: frame)
+            cameraButton.addTarget(self, action: "cameraButtonClicked", forControlEvents: .TouchUpInside)
+            cameraButton.setImage(DKImageResource.cameraImage(), forState: .Normal)
+            cameraButton.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
+            self.contentView.addSubview(cameraButton)
 
-      self.contentView.backgroundColor = UIColor(white: 0.9, alpha: 1.0)
-    }
+            self.contentView.backgroundColor = UIColor(white: 0.9, alpha: 0.9)
+        }
 
-    required init?(coder aDecoder: NSCoder) {
-      fatalError("init(coder:) has not been implemented")
-    }
+        required init?(coder aDecoder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
 
-    func cameraButtonClicked() {
-      if let didCameraButtonClicked = self.didCameraButtonClicked {
-        didCameraButtonClicked()
-      }
-    }
+        func cameraButtonClicked() {
+            if let didCameraButtonClicked = self.didCameraButtonClicked {
+                didCameraButtonClicked()
+            }
+        }
 
-  } /* DKImageCameraCell */
+    } /* DKImageCameraCell */
 
-  class DKAssetCell: UICollectionViewCell {
+    class DKAssetCell: UICollectionViewCell {
 
-    class DKImageCheckView: UIView {
+        class DKImageCheckView: UIView {
 
-      private lazy var checkImageView: UIImageView = {
-        let imageView = UIImageView(image: DKImageResource.checkedImage())
+            private lazy var checkImageView: UIImageView = {
+                let imageView = UIImageView(image: DKImageResource.checkedImage())
 
-        return imageView
-      }()
+                return imageView
+            }()
 
-      private lazy var checkLabel: UILabel = {
-        let label = UILabel()
-        label.font = UIFont.boldSystemFontOfSize(14)
-        label.textColor = UIColor.whiteColor()
-        label.textAlignment = .Right
+            private lazy var checkLabel: UILabel = {
+                let label = UILabel()
+                label.font = UIFont.boldSystemFontOfSize(14)
+                label.textColor = UIColor.whiteColor()
+                label.textAlignment = .Right
 
-        return label
-      }()
+                return label
+            }()
 
-      override init(frame: CGRect) {
-        super.init(frame: frame)
+            override init(frame: CGRect) {
+                super.init(frame: frame)
 
-        self.addSubview(checkImageView)
-        self.addSubview(checkLabel)
-      }
+                self.addSubview(checkImageView)
+                self.addSubview(checkLabel)
+            }
 
-      required init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-      }
+            required init?(coder aDecoder: NSCoder) {
+                fatalError("init(coder:) has not been implemented")
+            }
 
-      override func layoutSubviews() {
-        super.layoutSubviews()
+            override func layoutSubviews() {
+                super.layoutSubviews()
 
-        self.checkImageView.frame = self.bounds
-        self.checkLabel.frame = CGRect(x: 0, y: 5, width: self.bounds.width - 5, height: 20)
-      }
+                self.checkImageView.frame = self.bounds
+                self.checkLabel.frame = CGRect(x: 0, y: 5, width: self.bounds.width - 5, height: 20)
+            }
 
-    } /* DKImageCheckView */
+        } /* DKImageCheckView */
 
-    private var asset: DKAsset!
+        private var asset: DKAsset!
 
-    private let thumbnailImageView: UIImageView = {
-      let thumbnailImageView = UIImageView()
-      thumbnailImageView.contentMode = .ScaleAspectFill
-      thumbnailImageView.clipsToBounds = true
+        private let thumbnailImageView: UIImageView = {
+            let thumbnailImageView = UIImageView()
+            thumbnailImageView.contentMode = .ScaleAspectFill
+            thumbnailImageView.clipsToBounds = true
 
-      return thumbnailImageView
+            return thumbnailImageView
+        }()
+
+        private let checkView = DKImageCheckView()
+
+        override var selected: Bool {
+            didSet {
+                checkView.hidden = !super.selected
+            }
+        }
+
+        override init(frame: CGRect) {
+            super.init(frame: frame)
+
+            self.thumbnailImageView.frame = self.bounds
+            self.contentView.addSubview(self.thumbnailImageView)
+            self.contentView.addSubview(checkView)
+        }
+
+        required init?(coder aDecoder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        override func layoutSubviews() {
+            super.layoutSubviews()
+
+            self.thumbnailImageView.frame = self.bounds
+            checkView.frame = self.thumbnailImageView.frame
+        }
+
+    } /* DKAssetCell */
+
+    class DKVideoAssetCell: DKAssetCell {
+
+        override var asset: DKAsset! {
+            didSet {
+                let videoDurationLabel = self.videoInfoView.viewWithTag(-1) as! UILabel
+                let minutes: Int = Int(asset.duration!) / 60
+                let seconds: Int = Int(asset.duration!) % 60
+                videoDurationLabel.text = String(format: "\(minutes):%02d", seconds)
+            }
+        }
+
+        override var selected: Bool {
+            didSet {
+                if super.selected {
+                    self.videoInfoView.backgroundColor = UIColor(red: 20 / 255, green: 129 / 255, blue: 252 / 255, alpha: 1)
+                } else {
+                    self.videoInfoView.backgroundColor = UIColor(white: 0.0, alpha: 0.7)
+                }
+            }
+        }
+
+        private lazy var videoInfoView: UIView = {
+            let videoInfoView = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 0))
+
+            let videoImageView = UIImageView(image: DKImageResource.videoCameraIcon())
+            videoInfoView.addSubview(videoImageView)
+            videoImageView.center = CGPoint(x: videoImageView.bounds.width / 2 + 7, y: videoInfoView.bounds.height / 2)
+            videoImageView.autoresizingMask = [.FlexibleBottomMargin, .FlexibleTopMargin]
+
+            let videoDurationLabel = UILabel()
+            videoDurationLabel.tag = -1
+            videoDurationLabel.textAlignment = .Right
+            videoDurationLabel.font = UIFont.systemFontOfSize(12)
+            videoDurationLabel.textColor = UIColor.whiteColor()
+            videoInfoView.addSubview(videoDurationLabel)
+            videoDurationLabel.frame = CGRect(x: 0, y: 0, width: videoInfoView.bounds.width - 7, height: videoInfoView.bounds.height)
+            videoDurationLabel.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
+
+            return videoInfoView
+        }()
+
+        override init(frame: CGRect) {
+            super.init(frame: frame)
+
+            self.contentView.addSubview(videoInfoView)
+        }
+
+        required init?(coder aDecoder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        override func layoutSubviews() {
+            super.layoutSubviews()
+
+            let height: CGFloat = 30
+            self.videoInfoView.frame = CGRect(x: 0, y: self.contentView.bounds.height - height,
+                width: self.contentView.bounds.width, height: height)
+        }
+
+    } /* DKVideoAssetCell */
+
+    private lazy var selectGroupButton: UIButton = {
+        let button = UIButton()
+
+        let globalTitleColor = UINavigationBar.appearance().titleTextAttributes?[NSForegroundColorAttributeName] as? UIColor
+        button.setTitleColor(globalTitleColor ?? UIColor.blackColor(), forState: .Normal)
+
+        let globalTitleFont = UINavigationBar.appearance().titleTextAttributes?[NSFontAttributeName] as? UIFont
+        button.titleLabel!.font = globalTitleFont ?? UIFont.boldSystemFontOfSize(18.0)
+
+        button.addTarget(self, action: "showGroupSelector", forControlEvents: .TouchUpInside)
+        return button
     }()
 
-    private let checkView = DKImageCheckView()
+    internal var selectedGroupId: String?
 
-    override var selected: Bool {
-      didSet {
-        checkView.hidden = !super.selected
-      }
+    private var groupListVC: DKAssetGroupListVC!
+
+    private var hidesCamera :Bool = false
+
+    convenience init() {
+        let layout = DKAssetGroupGridLayout()
+        self.init(collectionViewLayout: layout)
     }
 
-    override init(frame: CGRect) {
-      super.init(frame: frame)
-
-      self.thumbnailImageView.frame = self.bounds
-      self.contentView.addSubview(self.thumbnailImageView)
-      self.contentView.addSubview(checkView)
+    override init(collectionViewLayout layout: UICollectionViewLayout) {
+        super.init(collectionViewLayout: layout)
     }
 
-    required init?(coder aDecoder: NSCoder) {
-      fatalError("init(coder:) has not been implemented")
-    }
+    private var currentViewSize: CGSize!
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
 
-    override func layoutSubviews() {
-      super.layoutSubviews()
-
-      self.thumbnailImageView.frame = self.bounds
-      checkView.frame = self.thumbnailImageView.frame
-    }
-
-  } /* DKAssetCell */
-
-  class DKVideoAssetCell: DKAssetCell {
-
-    override var asset: DKAsset! {
-      didSet {
-        let videoDurationLabel = self.videoInfoView.viewWithTag(-1) as! UILabel
-        let minutes: Int = Int(asset.duration!) / 60
-        let seconds: Int = Int(asset.duration!) % 60
-        videoDurationLabel.text = String(format: "\(minutes):%02d", seconds)
-      }
-    }
-
-    override var selected: Bool {
-      didSet {
-        if super.selected {
-          self.videoInfoView.backgroundColor = UIColor(red: 20 / 255, green: 129 / 255, blue: 252 / 255, alpha: 1)
+        if let currentViewSize = self.currentViewSize where CGSizeEqualToSize(currentViewSize, self.view.bounds.size) {
+            return
         } else {
-          self.videoInfoView.backgroundColor = UIColor(white: 0.0, alpha: 0.7)
+            currentViewSize = self.view.bounds.size
         }
-      }
+
+        let layout = DKAssetGroupGridLayout(contentSize: self.view.bounds.size)
+        self.collectionView!.setCollectionViewLayout(layout, animated: true) { completed in
+            self.collectionView!.reloadItemsAtIndexPaths(self.collectionView!.indexPathsForVisibleItems())
+        }
     }
 
-    private lazy var videoInfoView: UIView = {
-      let videoInfoView = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 0))
+    private lazy var groupImageRequestOptions: PHImageRequestOptions = {
+        let options = PHImageRequestOptions()
+        options.deliveryMode = .Opportunistic
+        options.resizeMode = .Exact;
 
-      let videoImageView = UIImageView(image: DKImageResource.videoCameraIcon())
-      videoInfoView.addSubview(videoImageView)
-      videoImageView.center = CGPoint(x: videoImageView.bounds.width / 2 + 7, y: videoInfoView.bounds.height / 2)
-      videoImageView.autoresizingMask = [.FlexibleBottomMargin, .FlexibleTopMargin]
-
-      let videoDurationLabel = UILabel()
-      videoDurationLabel.tag = -1
-      videoDurationLabel.textAlignment = .Right
-      videoDurationLabel.font = UIFont.systemFontOfSize(12)
-      videoDurationLabel.textColor = UIColor.whiteColor()
-      videoInfoView.addSubview(videoDurationLabel)
-      videoDurationLabel.frame = CGRect(x: 0, y: 0, width: videoInfoView.bounds.width - 7, height: videoInfoView.bounds.height)
-      videoDurationLabel.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
-
-      return videoInfoView
+        return options
     }()
 
-    override init(frame: CGRect) {
-      super.init(frame: frame)
-
-      self.contentView.addSubview(videoInfoView)
-    }
-
     required init?(coder aDecoder: NSCoder) {
-      fatalError("init(coder:) has not been implemented")
+        fatalError("init(coder:) has not been implemented")
     }
 
-    override func layoutSubviews() {
-      super.layoutSubviews()
+    override func viewDidLoad() {
+        super.viewDidLoad()
 
-      let height: CGFloat = 30
-      self.videoInfoView.frame = CGRect(x: 0, y: self.contentView.bounds.height - height,
-        width: self.contentView.bounds.width, height: height)
+        let backgroundColor = overrideBackgroundColor ?? UIColor.whiteColor()
+        self.view.backgroundColor = backgroundColor
+
+        self.collectionView!.backgroundColor = overrideBackgroundColor
+        self.collectionView!.allowsMultipleSelection = true
+        self.collectionView!.registerClass(DKImageCameraCell.self, forCellWithReuseIdentifier: DKImageCameraIdentifier)
+        self.collectionView!.registerClass(DKAssetCell.self, forCellWithReuseIdentifier: DKImageAssetIdentifier)
+        self.collectionView!.registerClass(DKVideoAssetCell.self, forCellWithReuseIdentifier: DKVideoAssetIdentifier)
+
+        self.hidesCamera = !self.imagePickerController!.sourceType.contains(.Camera)
+        self.checkPhotoPermission()
     }
 
-  } /* DKVideoAssetCell */
-
-  private lazy var selectGroupButton: UIButton = {
-    let button = UIButton()
-
-    let globalTitleColor = UINavigationBar.appearance().titleTextAttributes?[NSForegroundColorAttributeName] as? UIColor
-    button.setTitleColor(globalTitleColor ?? UIColor.blackColor(), forState: .Normal)
-
-    let globalTitleFont = UINavigationBar.appearance().titleTextAttributes?[NSFontAttributeName] as? UIFont
-    button.titleLabel!.font = globalTitleFont ?? UIFont.boldSystemFontOfSize(18.0)
-
-    button.addTarget(self, action: "showGroupSelector", forControlEvents: .TouchUpInside)
-    return button
-  }()
-
-  internal var selectedGroupId: String?
-
-  private var groupListVC: DKAssetGroupListVC!
-
-  private var hidesCamera :Bool = false
-
-  convenience init() {
-    let layout = DKAssetGroupGridLayout()
-    self.init(collectionViewLayout: layout)
-  }
-
-  override init(collectionViewLayout layout: UICollectionViewLayout) {
-    super.init(collectionViewLayout: layout)
-  }
-
-  private var currentViewSize: CGSize!
-  override func viewWillLayoutSubviews() {
-    super.viewWillLayoutSubviews()
-
-    if let currentViewSize = self.currentViewSize where CGSizeEqualToSize(currentViewSize, self.view.bounds.size) {
-      return
-    } else {
-      currentViewSize = self.view.bounds.size
-    }
-
-    let layout = DKAssetGroupGridLayout(contentSize: self.view.bounds.size)
-    self.collectionView!.setCollectionViewLayout(layout, animated: true) { completed in
-      self.collectionView!.reloadItemsAtIndexPaths(self.collectionView!.indexPathsForVisibleItems())
-    }
-  }
-
-  private lazy var groupImageRequestOptions: PHImageRequestOptions = {
-    let options = PHImageRequestOptions()
-    options.deliveryMode = .Opportunistic
-    options.resizeMode = .Exact;
-
-    return options
-  }()
-
-  required init?(coder aDecoder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
-
-  override func viewDidLoad() {
-    super.viewDidLoad()
-
-    let backgroundColor = overrideBackgroundColor ?? UIColor.whiteColor()
-    self.view.backgroundColor = backgroundColor
-
-    self.collectionView!.backgroundColor = overrideBackgroundColor
-    self.collectionView!.allowsMultipleSelection = true
-    self.collectionView!.registerClass(DKImageCameraCell.self, forCellWithReuseIdentifier: DKImageCameraIdentifier)
-    self.collectionView!.registerClass(DKAssetCell.self, forCellWithReuseIdentifier: DKImageAssetIdentifier)
-    self.collectionView!.registerClass(DKVideoAssetCell.self, forCellWithReuseIdentifier: DKVideoAssetIdentifier)
-
-    self.hidesCamera = !self.imagePickerController!.sourceType.contains(.Camera)
-    self.checkPhotoPermission()
-  }
-
-  internal func checkPhotoPermission() {
-    func photoDenied() {
-      self.view.addSubview(DKPermissionView.permissionView(.Photo))
-      self.collectionView?.hidden = true
-    }
-
-    func setup() {
-      getImageManager().groupDataManager.addObserver(self)
-      self.groupListVC = DKAssetGroupListVC(selectedGroupDidChangeBlock: { [unowned self] groupId in
-        self.selectAssetGroup(groupId)
-        }, defaultAssetGroup: self.imagePickerController?.defaultAssetGroup)
-      self.groupListVC.loadGroups()
-    }
-
-    DKImageManager.checkPhotoPermission { granted in
-      granted ? setup() : photoDenied()
-    }
-  }
-
-  func selectAssetGroup(groupId: String?) {
-    if self.selectedGroupId == groupId {
-      return
-    }
-
-    self.selectedGroupId = groupId
-    self.updateTitleView()
-    self.collectionView!.reloadData()
-  }
-
-  func updateTitleView() {
-    let group = getImageManager().groupDataManager.fetchGroupWithGroupId(self.selectedGroupId!)
-    self.title = group.groupName
-
-    let groupsCount = getImageManager().groupDataManager.groupIds?.count
-    self.selectGroupButton.setTitle(group.groupName + (groupsCount > 1 ? "  \u{25be}" : "" ), forState: .Normal)
-    self.selectGroupButton.sizeToFit()
-    self.selectGroupButton.enabled = groupsCount > 1
-
-    self.navigationItem.titleView = self.selectGroupButton
-  }
-
-  func showGroupSelector() {
-    DKPopoverViewController.popoverViewController(self.groupListVC, fromView: self.selectGroupButton)
-  }
-
-  // MARK: - Cells
-
-  func cameraCellForIndexPath(indexPath: NSIndexPath) -> UICollectionViewCell {
-    let cell = collectionView!.dequeueReusableCellWithReuseIdentifier(DKImageCameraIdentifier, forIndexPath: indexPath) as! DKImageCameraCell
-    if let cameraIcon = cameraIcon {
-      cell.cameraButton.setImage(cameraIcon, forState: .Normal)
-    }
-
-    cell.didCameraButtonClicked = { [unowned self] () in
-      if UIImagePickerController.isSourceTypeAvailable(.Camera) {
-        self.imagePickerController?.presentCamera()
-      }
-    }
-
-    return cell
-  }
-
-  func assetCellForIndexPath(indexPath: NSIndexPath) -> UICollectionViewCell {
-    let assetIndex = (indexPath.row - (self.hidesCamera ? 0 : 1))
-    let group = getImageManager().groupDataManager.fetchGroupWithGroupId(self.selectedGroupId!)
-
-    let asset = getImageManager().groupDataManager.fetchAssetWithGroup(group, index: assetIndex)
-
-    var cell: DKAssetCell!
-    var identifier: String!
-    if asset.isVideo {
-      identifier = DKVideoAssetIdentifier
-    } else {
-      identifier = DKImageAssetIdentifier
-    }
-
-    cell = self.collectionView!.dequeueReusableCellWithReuseIdentifier(identifier, forIndexPath: indexPath) as! DKAssetCell
-    cell.asset = asset
-    let tag = indexPath.row + 1
-    cell.tag = tag
-
-    let itemSize = self.collectionView!.collectionViewLayout.layoutAttributesForItemAtIndexPath(indexPath)!.size
-    asset.fetchImageWithSize(itemSize.toPixel(), options: self.groupImageRequestOptions) { image, info in
-      if cell.tag == tag {
-        cell.thumbnailImageView.image = image
-      }
-    }
-
-    if let index = self.imagePickerController!.selectedAssets.indexOf(asset) {
-      cell.selected = true
-      cell.checkView.checkLabel.text = "\(index + 1)"
-      self.collectionView!.selectItemAtIndexPath(indexPath, animated: false, scrollPosition: UICollectionViewScrollPosition.None)
-    } else {
-      cell.selected = false
-      self.collectionView!.deselectItemAtIndexPath(indexPath, animated: false)
-    }
-
-    return cell
-  }
-
-  // MARK: - UICollectionViewDelegate, UICollectionViewDataSource methods
-
-  override func collectionView(collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-    guard let selectedGroup = self.selectedGroupId else { return 0 }
-
-    let group = getImageManager().groupDataManager.fetchGroupWithGroupId(selectedGroup)
-    return (group.totalCount ?? 0) + (self.hidesCamera ? 0 : 1)
-  }
-
-  override func collectionView(collectionView: UICollectionView, cellForItemAtIndexPath indexPath: NSIndexPath) -> UICollectionViewCell {
-    if indexPath.row == 0 && !self.hidesCamera {
-      return self.cameraCellForIndexPath(indexPath)
-    } else {
-      return self.assetCellForIndexPath(indexPath)
-    }
-  }
-
-  override func collectionView(collectionView: UICollectionView, shouldSelectItemAtIndexPath indexPath: NSIndexPath) -> Bool {
-    if let firstSelectedAsset = self.imagePickerController?.selectedAssets.first,
-      selectedAsset = (collectionView.cellForItemAtIndexPath(indexPath) as? DKAssetCell)?.asset
-      where self.imagePickerController?.allowMultipleTypes == false && firstSelectedAsset.isVideo != selectedAsset.isVideo {
-
-        UIAlertView(title: DKImageLocalizedStringWithKey("selectPhotosOrVideos"),
-          message: DKImageLocalizedStringWithKey("selectPhotosOrVideosError"),
-          delegate: nil,
-          cancelButtonTitle: DKImageLocalizedStringWithKey("ok")).show()
-
-        return false
-    }
-
-    return self.imagePickerController!.selectedAssets.count < self.imagePickerController!.maxSelectableCount
-  }
-
-  override func collectionView(collectionView: UICollectionView, didSelectItemAtIndexPath indexPath: NSIndexPath) {
-    let selectedAsset = (collectionView.cellForItemAtIndexPath(indexPath) as? DKAssetCell)?.asset
-    self.imagePickerController?.selectedImage(selectedAsset!)
-
-    let cell = collectionView.cellForItemAtIndexPath(indexPath) as! DKAssetCell
-    cell.checkView.checkLabel.text = "\(self.imagePickerController!.selectedAssets.count)"
-  }
-
-  override func collectionView(collectionView: UICollectionView, didDeselectItemAtIndexPath indexPath: NSIndexPath) {
-    if let removedAsset = (collectionView.cellForItemAtIndexPath(indexPath) as? DKAssetCell)?.asset {
-      let removedIndex = self.imagePickerController!.selectedAssets.indexOf(removedAsset)!
-
-      /// Minimize the number of cycles.
-      let indexPathsForSelectedItems = collectionView.indexPathsForSelectedItems() as [NSIndexPath]!
-      let indexPathsForVisibleItems = collectionView.indexPathsForVisibleItems()
-
-      let intersect = Set(indexPathsForVisibleItems).intersect(Set(indexPathsForSelectedItems))
-
-      for selectedIndexPath in intersect {
-        if let selectedCell = (collectionView.cellForItemAtIndexPath(selectedIndexPath) as? DKAssetCell) {
-          let selectedIndex = self.imagePickerController!.selectedAssets.indexOf(selectedCell.asset)!
-
-          if selectedIndex > removedIndex {
-            selectedCell.checkView.checkLabel.text = "\(Int(selectedCell.checkView.checkLabel.text!)! - 1)"
-          }
+    internal func checkPhotoPermission() {
+        func photoDenied() {
+            self.view.addSubview(DKPermissionView.permissionView(.Photo))
+            self.collectionView?.hidden = true
         }
-      }
 
-      self.imagePickerController?.unselectedImage(removedAsset)
-    }
-  }
-
-  // MARK: - DKGroupDataManagerObserver methods
-
-  func groupDidUpdate(groupId: String) {
-    if self.selectedGroupId == groupId {
-      self.updateTitleView()
-    }
-  }
-
-  func group(groupId: String, didRemoveAssets assets: [DKAsset]) {
-    if let imagePickerController = self.imagePickerController {
-      for (_, selectedAsset) in imagePickerController.selectedAssets.enumerate() {
-        for removedAsset in assets {
-          if selectedAsset.isEqual(removedAsset) {
-            imagePickerController.unselectedImage(selectedAsset)
-          }
+        func setup() {
+            getImageManager().groupDataManager.addObserver(self)
+            self.groupListVC = DKAssetGroupListVC(selectedGroupDidChangeBlock: { [unowned self] groupId in
+                self.selectAssetGroup(groupId)
+                }, defaultAssetGroup: self.imagePickerController?.defaultAssetGroup)
+            self.groupListVC.loadGroups()
         }
-      }
-      if self.selectedGroupId == groupId {
+
+        DKImageManager.checkPhotoPermission { granted in
+            granted ? setup() : photoDenied()
+        }
+    }
+
+    func selectAssetGroup(groupId: String?) {
+        if self.selectedGroupId == groupId {
+            return
+        }
+
+        self.selectedGroupId = groupId
+        self.updateTitleView()
+        self.collectionView!.reloadData()
+    }
+
+    func updateTitleView() {
+        let group = getImageManager().groupDataManager.fetchGroupWithGroupId(self.selectedGroupId!)
+        self.title = group.groupName
+
+        let groupsCount = getImageManager().groupDataManager.groupIds?.count
+        self.selectGroupButton.setTitle(group.groupName + (groupsCount > 1 ? "  \u{25be}" : "" ), forState: .Normal)
+        self.selectGroupButton.sizeToFit()
+        self.selectGroupButton.enabled = groupsCount > 1
+
+        self.navigationItem.titleView = self.selectGroupButton
+    }
+
+    func showGroupSelector() {
+        DKPopoverViewController.popoverViewController(self.groupListVC, fromView: self.selectGroupButton)
+    }
+
+    // MARK: - Cells
+
+    func cameraCellForIndexPath(indexPath: NSIndexPath) -> UICollectionViewCell {
+        let cell = collectionView!.dequeueReusableCellWithReuseIdentifier(DKImageCameraIdentifier, forIndexPath: indexPath) as! DKImageCameraCell
+        if let cameraIcon = cameraIcon {
+            cell.cameraButton.setImage(cameraIcon, forState: .Normal)
+        }
+
+        cell.didCameraButtonClicked = { [unowned self] () in
+            if UIImagePickerController.isSourceTypeAvailable(.Camera) {
+                self.imagePickerController?.presentCamera()
+            }
+        }
+
+        return cell
+    }
+
+    func assetCellForIndexPath(indexPath: NSIndexPath) -> UICollectionViewCell {
+        let assetIndex = (indexPath.row - (self.hidesCamera ? 0 : 1))
+        let group = getImageManager().groupDataManager.fetchGroupWithGroupId(self.selectedGroupId!)
+
+        let asset = getImageManager().groupDataManager.fetchAssetWithGroup(group, index: assetIndex)
+
+        var cell: DKAssetCell!
+        var identifier: String!
+        if asset.isVideo {
+            identifier = DKVideoAssetIdentifier
+        } else {
+            identifier = DKImageAssetIdentifier
+        }
+
+        cell = self.collectionView!.dequeueReusableCellWithReuseIdentifier(identifier, forIndexPath: indexPath) as! DKAssetCell
+        cell.asset = asset
+        let tag = indexPath.row + 1
+        cell.tag = tag
+
+        let itemSize = self.collectionView!.collectionViewLayout.layoutAttributesForItemAtIndexPath(indexPath)!.size
+        asset.fetchImageWithSize(itemSize.toPixel(), options: self.groupImageRequestOptions) { image, info in
+            if cell.tag == tag {
+                cell.thumbnailImageView.image = image
+            }
+        }
+
+        if let index = self.imagePickerController!.selectedAssets.indexOf(asset) {
+            cell.selected = true
+            cell.checkView.checkLabel.text = "\(index + 1)"
+            self.collectionView!.selectItemAtIndexPath(indexPath, animated: false, scrollPosition: UICollectionViewScrollPosition.None)
+        } else {
+            cell.selected = false
+            self.collectionView!.deselectItemAtIndexPath(indexPath, animated: false)
+        }
+
+        return cell
+    }
+
+    // MARK: - UICollectionViewDelegate, UICollectionViewDataSource methods
+
+    override func collectionView(collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        guard let selectedGroup = self.selectedGroupId else { return 0 }
+
+        let group = getImageManager().groupDataManager.fetchGroupWithGroupId(selectedGroup)
+        return (group.totalCount ?? 0) + (self.hidesCamera ? 0 : 1)
+    }
+
+    override func collectionView(collectionView: UICollectionView, cellForItemAtIndexPath indexPath: NSIndexPath) -> UICollectionViewCell {
+        if indexPath.row == 0 && !self.hidesCamera {
+            return self.cameraCellForIndexPath(indexPath)
+        } else {
+            return self.assetCellForIndexPath(indexPath)
+        }
+    }
+
+    override func collectionView(collectionView: UICollectionView, shouldSelectItemAtIndexPath indexPath: NSIndexPath) -> Bool {
+        if let firstSelectedAsset = self.imagePickerController?.selectedAssets.first,
+            selectedAsset = (collectionView.cellForItemAtIndexPath(indexPath) as? DKAssetCell)?.asset
+            where self.imagePickerController?.allowMultipleTypes == false && firstSelectedAsset.isVideo != selectedAsset.isVideo {
+
+                UIAlertView(title: DKImageLocalizedStringWithKey("selectPhotosOrVideos"),
+                    message: DKImageLocalizedStringWithKey("selectPhotosOrVideosError"),
+                    delegate: nil,
+                    cancelButtonTitle: DKImageLocalizedStringWithKey("ok")).show()
+
+                return false
+        }
+
+        return self.imagePickerController!.selectedAssets.count < self.imagePickerController!.maxSelectableCount
+    }
+
+    override func collectionView(collectionView: UICollectionView, didSelectItemAtIndexPath indexPath: NSIndexPath) {
+        let selectedAsset = (collectionView.cellForItemAtIndexPath(indexPath) as? DKAssetCell)?.asset
+        self.imagePickerController?.selectedImage(selectedAsset!)
+        
+        let cell = collectionView.cellForItemAtIndexPath(indexPath) as! DKAssetCell
+        cell.checkView.checkLabel.text = "\(self.imagePickerController!.selectedAssets.count)"
+    }
+    
+    override func collectionView(collectionView: UICollectionView, didDeselectItemAtIndexPath indexPath: NSIndexPath) {
+        if let removedAsset = (collectionView.cellForItemAtIndexPath(indexPath) as? DKAssetCell)?.asset {
+            let removedIndex = self.imagePickerController!.selectedAssets.indexOf(removedAsset)!
+            
+            /// Minimize the number of cycles.
+            let indexPathsForSelectedItems = collectionView.indexPathsForSelectedItems() as [NSIndexPath]!
+            let indexPathsForVisibleItems = collectionView.indexPathsForVisibleItems()
+            
+            let intersect = Set(indexPathsForVisibleItems).intersect(Set(indexPathsForSelectedItems))
+            
+            for selectedIndexPath in intersect {
+                if let selectedCell = (collectionView.cellForItemAtIndexPath(selectedIndexPath) as? DKAssetCell) {
+                    let selectedIndex = self.imagePickerController!.selectedAssets.indexOf(selectedCell.asset)!
+                    
+                    if selectedIndex > removedIndex {
+                        selectedCell.checkView.checkLabel.text = "\(Int(selectedCell.checkView.checkLabel.text!)! - 1)"
+                    }
+                }
+            }
+            
+            self.imagePickerController?.unselectedImage(removedAsset)
+        }
+    }
+    
+    // MARK: - DKGroupDataManagerObserver methods
+    
+    func groupDidUpdate(groupId: String) {
+        if self.selectedGroupId == groupId {
+            self.updateTitleView()
+        }
+    }
+    
+    func group(groupId: String, didRemoveAssets assets: [DKAsset]) {
+        if let imagePickerController = self.imagePickerController {
+            for (_, selectedAsset) in imagePickerController.selectedAssets.enumerate() {
+                for removedAsset in assets {
+                    if selectedAsset.isEqual(removedAsset) {
+                        imagePickerController.unselectedImage(selectedAsset)
+                    }
+                }
+            }
+            if self.selectedGroupId == groupId {
+                self.collectionView?.reloadData()
+            }
+        }
+    }
+    
+    func group(groupId: String, didInsertAssets assets: [DKAsset]) {
         self.collectionView?.reloadData()
-      }
     }
-  }
-
-  func group(groupId: String, didInsertAssets assets: [DKAsset]) {
-    self.collectionView?.reloadData()
-  }
-
+    
 }

--- a/DKImagePickerController/View/DKAssetGroupDetailVC.swift
+++ b/DKImagePickerController/View/DKAssetGroupDetailVC.swift
@@ -16,432 +16,440 @@ private let DKVideoAssetIdentifier = "DKVideoAssetIdentifier"
 
 // Show all images in the asset group
 internal class DKAssetGroupDetailVC: UICollectionViewController, DKGroupDataManagerObserver {
-    
-    class DKImageCameraCell: UICollectionViewCell {
-        
-        var didCameraButtonClicked: (() -> Void)?
-        
-        override init(frame: CGRect) {
-            super.init(frame: frame)
-            
-            let cameraButton = UIButton(frame: frame)
-            cameraButton.addTarget(self, action: "cameraButtonClicked", forControlEvents: .TouchUpInside)
-            cameraButton.setImage(DKImageResource.cameraImage(), forState: .Normal)
-            cameraButton.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
-            self.contentView.addSubview(cameraButton)
-            
-            self.contentView.backgroundColor = UIColor(white: 0.9, alpha: 1.0)
-        }
 
-        required init?(coder aDecoder: NSCoder) {
-            fatalError("init(coder:) has not been implemented")
-        }
-        
-        func cameraButtonClicked() {
-            if let didCameraButtonClicked = self.didCameraButtonClicked {
-                didCameraButtonClicked()
-            }
-        }
-        
-    } /* DKImageCameraCell */
+  internal var cameraIcon: UIImage?
+  internal var overrideBackgroundColor: UIColor?
 
-    class DKAssetCell: UICollectionViewCell {
-        
-        class DKImageCheckView: UIView {
-            
-            private lazy var checkImageView: UIImageView = {
-                let imageView = UIImageView(image: DKImageResource.checkedImage())
-                
-                return imageView
-            }()
-            
-            private lazy var checkLabel: UILabel = {
-                let label = UILabel()
-                label.font = UIFont.boldSystemFontOfSize(14)
-                label.textColor = UIColor.whiteColor()
-                label.textAlignment = .Right
-                
-                return label
-            }()
-            
-            override init(frame: CGRect) {
-                super.init(frame: frame)
-                
-                self.addSubview(checkImageView)
-                self.addSubview(checkLabel)
-            }
+  class DKImageCameraCell: UICollectionViewCell {
 
-            required init?(coder aDecoder: NSCoder) {
-                fatalError("init(coder:) has not been implemented")
-            }
-            
-            override func layoutSubviews() {
-                super.layoutSubviews()
-                
-                self.checkImageView.frame = self.bounds
-                self.checkLabel.frame = CGRect(x: 0, y: 5, width: self.bounds.width - 5, height: 20)
-            }
-            
-        } /* DKImageCheckView */
-		
-		private var asset: DKAsset!
-		
-        private let thumbnailImageView: UIImageView = {
-            let thumbnailImageView = UIImageView()
-            thumbnailImageView.contentMode = .ScaleAspectFill
-            thumbnailImageView.clipsToBounds = true
-            
-            return thumbnailImageView
-        }()
-        
-        private let checkView = DKImageCheckView()
-        
-        override var selected: Bool {
-            didSet {
-                checkView.hidden = !super.selected
-            }
-        }
-        
-        override init(frame: CGRect) {
-            super.init(frame: frame)
-            
-            self.thumbnailImageView.frame = self.bounds
-            self.contentView.addSubview(self.thumbnailImageView)
-            self.contentView.addSubview(checkView)
-        }
-        
-        required init?(coder aDecoder: NSCoder) {
-            fatalError("init(coder:) has not been implemented")
-        }
-        
-        override func layoutSubviews() {
-            super.layoutSubviews()
-			
-            self.thumbnailImageView.frame = self.bounds
-            checkView.frame = self.thumbnailImageView.frame
-        }
-		
-    } /* DKAssetCell */
-    
-    class DKVideoAssetCell: DKAssetCell {
-		
-		override var asset: DKAsset! {
-			didSet {
-				let videoDurationLabel = self.videoInfoView.viewWithTag(-1) as! UILabel
-				let minutes: Int = Int(asset.duration!) / 60
-				let seconds: Int = Int(asset.duration!) % 60
-				videoDurationLabel.text = String(format: "\(minutes):%02d", seconds)
-			}
-		}
-		
-        override var selected: Bool {
-            didSet {
-                if super.selected {
-                    self.videoInfoView.backgroundColor = UIColor(red: 20 / 255, green: 129 / 255, blue: 252 / 255, alpha: 1)
-                } else {
-                    self.videoInfoView.backgroundColor = UIColor(white: 0.0, alpha: 0.7)
-                }
-            }
-        }
-        
-        private lazy var videoInfoView: UIView = {
-            let videoInfoView = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 0))
+    internal var cameraButton: UIButton!
+    var didCameraButtonClicked: (() -> Void)?
 
-            let videoImageView = UIImageView(image: DKImageResource.videoCameraIcon())
-            videoInfoView.addSubview(videoImageView)
-            videoImageView.center = CGPoint(x: videoImageView.bounds.width / 2 + 7, y: videoInfoView.bounds.height / 2)
-            videoImageView.autoresizingMask = [.FlexibleBottomMargin, .FlexibleTopMargin]
-            
-            let videoDurationLabel = UILabel()
-            videoDurationLabel.tag = -1
-            videoDurationLabel.textAlignment = .Right
-            videoDurationLabel.font = UIFont.systemFontOfSize(12)
-            videoDurationLabel.textColor = UIColor.whiteColor()
-            videoInfoView.addSubview(videoDurationLabel)
-            videoDurationLabel.frame = CGRect(x: 0, y: 0, width: videoInfoView.bounds.width - 7, height: videoInfoView.bounds.height)
-            videoDurationLabel.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
-            
-            return videoInfoView
-        }()
-        
-        override init(frame: CGRect) {
-            super.init(frame: frame)
-            
-            self.contentView.addSubview(videoInfoView)
-        }
+    override init(frame: CGRect) {
+      super.init(frame: frame)
 
-        required init?(coder aDecoder: NSCoder) {
-            fatalError("init(coder:) has not been implemented")
-        }
-        
-        override func layoutSubviews() {
-            super.layoutSubviews()
-            
-            let height: CGFloat = 30
-            self.videoInfoView.frame = CGRect(x: 0, y: self.contentView.bounds.height - height,
-                width: self.contentView.bounds.width, height: height)
-        }
-        
-    } /* DKVideoAssetCell */
-	
-    private lazy var selectGroupButton: UIButton = {
-        let button = UIButton()
-		
-		let globalTitleColor = UINavigationBar.appearance().titleTextAttributes?[NSForegroundColorAttributeName] as? UIColor
-		button.setTitleColor(globalTitleColor ?? UIColor.blackColor(), forState: .Normal)
-		
-		let globalTitleFont = UINavigationBar.appearance().titleTextAttributes?[NSFontAttributeName] as? UIFont
-		button.titleLabel!.font = globalTitleFont ?? UIFont.boldSystemFontOfSize(18.0)
-		
-		button.addTarget(self, action: "showGroupSelector", forControlEvents: .TouchUpInside)
-        return button
-    }()
-		
-    internal var selectedGroupId: String?
-    
-	private var groupListVC: DKAssetGroupListVC!
-    
-    private var hidesCamera :Bool = false
-	
-    convenience init() {
-        let layout = DKAssetGroupGridLayout()
-        self.init(collectionViewLayout: layout)
+      cameraButton = UIButton(frame: frame)
+      cameraButton.addTarget(self, action: "cameraButtonClicked", forControlEvents: .TouchUpInside)
+      cameraButton.setImage(DKImageResource.cameraImage(), forState: .Normal)
+      cameraButton.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
+      self.contentView.addSubview(cameraButton)
+
+      self.contentView.backgroundColor = UIColor(white: 0.9, alpha: 1.0)
     }
-	
-	override init(collectionViewLayout layout: UICollectionViewLayout) {
-		super.init(collectionViewLayout: layout)
-	}
-	
-	private var currentViewSize: CGSize!
-	override func viewWillLayoutSubviews() {
-		super.viewWillLayoutSubviews()
-		
-		if let currentViewSize = self.currentViewSize where CGSizeEqualToSize(currentViewSize, self.view.bounds.size) {
-			return
-		} else {
-			currentViewSize = self.view.bounds.size
-		}
-		
-		let layout = DKAssetGroupGridLayout(contentSize: self.view.bounds.size)
-		self.collectionView!.setCollectionViewLayout(layout, animated: true) { completed in
-			self.collectionView!.reloadItemsAtIndexPaths(self.collectionView!.indexPathsForVisibleItems())
-		}
-	}
-	
-	private lazy var groupImageRequestOptions: PHImageRequestOptions = {
-		let options = PHImageRequestOptions()
-		options.deliveryMode = .Opportunistic
-		options.resizeMode = .Exact;
-		
-		return options
-	}()
-    
+
     required init?(coder aDecoder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+
+    func cameraButtonClicked() {
+      if let didCameraButtonClicked = self.didCameraButtonClicked {
+        didCameraButtonClicked()
+      }
+    }
+
+  } /* DKImageCameraCell */
+
+  class DKAssetCell: UICollectionViewCell {
+
+    class DKImageCheckView: UIView {
+
+      private lazy var checkImageView: UIImageView = {
+        let imageView = UIImageView(image: DKImageResource.checkedImage())
+
+        return imageView
+      }()
+
+      private lazy var checkLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.boldSystemFontOfSize(14)
+        label.textColor = UIColor.whiteColor()
+        label.textAlignment = .Right
+
+        return label
+      }()
+
+      override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        self.addSubview(checkImageView)
+        self.addSubview(checkLabel)
+      }
+
+      required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        self.view.backgroundColor = UIColor.whiteColor()
-        
-        self.collectionView!.backgroundColor = UIColor.whiteColor()
-        self.collectionView!.allowsMultipleSelection = true
-        self.collectionView!.registerClass(DKImageCameraCell.self, forCellWithReuseIdentifier: DKImageCameraIdentifier)
-        self.collectionView!.registerClass(DKAssetCell.self, forCellWithReuseIdentifier: DKImageAssetIdentifier)
-        self.collectionView!.registerClass(DKVideoAssetCell.self, forCellWithReuseIdentifier: DKVideoAssetIdentifier)
-		
-		self.hidesCamera = !self.imagePickerController!.sourceType.contains(.Camera)
-		self.checkPhotoPermission()
-    }
-	
-	internal func checkPhotoPermission() {
-		func photoDenied() {
-			self.view.addSubview(DKPermissionView.permissionView(.Photo))
-			self.collectionView?.hidden = true
-		}
-		
-		func setup() {
-			getImageManager().groupDataManager.addObserver(self)
-			self.groupListVC = DKAssetGroupListVC(selectedGroupDidChangeBlock: { [unowned self] groupId in
-				self.selectAssetGroup(groupId)
-			}, defaultAssetGroup: self.imagePickerController?.defaultAssetGroup)
-			self.groupListVC.loadGroups()
-		}
-		
-		DKImageManager.checkPhotoPermission { granted in
-			granted ? setup() : photoDenied()
-		}
-	}
-	
-    func selectAssetGroup(groupId: String?) {
-        if self.selectedGroupId == groupId {
-            return
-        }
-        
-        self.selectedGroupId = groupId
-		self.updateTitleView()
-		self.collectionView!.reloadData()
-    }
-	
-	func updateTitleView() {
-		let group = getImageManager().groupDataManager.fetchGroupWithGroupId(self.selectedGroupId!)
-		self.title = group.groupName
-		
-		let groupsCount = getImageManager().groupDataManager.groupIds?.count
-		self.selectGroupButton.setTitle(group.groupName + (groupsCount > 1 ? "  \u{25be}" : "" ), forState: .Normal)
-		self.selectGroupButton.sizeToFit()
-		self.selectGroupButton.enabled = groupsCount > 1
-		
-		self.navigationItem.titleView = self.selectGroupButton
-	}
-    
-    func showGroupSelector() {
-        DKPopoverViewController.popoverViewController(self.groupListVC, fromView: self.selectGroupButton)
-    }
-	
-    // MARK: - Cells
+      }
 
-    func cameraCellForIndexPath(indexPath: NSIndexPath) -> UICollectionViewCell {
-        let cell = collectionView!.dequeueReusableCellWithReuseIdentifier(DKImageCameraIdentifier, forIndexPath: indexPath) as! DKImageCameraCell
-        
-        cell.didCameraButtonClicked = { [unowned self] () in
-            if UIImagePickerController.isSourceTypeAvailable(.Camera) {
-                self.imagePickerController?.presentCamera()
-            }
-        }
+      override func layoutSubviews() {
+        super.layoutSubviews()
 
-        return cell
-	}
-	
-	func assetCellForIndexPath(indexPath: NSIndexPath) -> UICollectionViewCell {
-		let assetIndex = (indexPath.row - (self.hidesCamera ? 0 : 1))
-		let group = getImageManager().groupDataManager.fetchGroupWithGroupId(self.selectedGroupId!)
-		
-		let asset = getImageManager().groupDataManager.fetchAssetWithGroup(group, index: assetIndex)
-		
-		var cell: DKAssetCell!
-		var identifier: String!
-		if asset.isVideo {
-			identifier = DKVideoAssetIdentifier
-		} else {
-			identifier = DKImageAssetIdentifier
-		}
-		
-		cell = self.collectionView!.dequeueReusableCellWithReuseIdentifier(identifier, forIndexPath: indexPath) as! DKAssetCell
-		cell.asset = asset
-		let tag = indexPath.row + 1
-		cell.tag = tag
-		
-		let itemSize = self.collectionView!.collectionViewLayout.layoutAttributesForItemAtIndexPath(indexPath)!.size
-		asset.fetchImageWithSize(itemSize.toPixel(), options: self.groupImageRequestOptions) { image, info in
-			if cell.tag == tag {
-				cell.thumbnailImageView.image = image
-			}
-		}
-		
-		if let index = self.imagePickerController!.selectedAssets.indexOf(asset) {
-			cell.selected = true
-			cell.checkView.checkLabel.text = "\(index + 1)"
-			self.collectionView!.selectItemAtIndexPath(indexPath, animated: false, scrollPosition: UICollectionViewScrollPosition.None)
-		} else {
-			cell.selected = false
-			self.collectionView!.deselectItemAtIndexPath(indexPath, animated: false)
-		}
-		
-		return cell
-	}
+        self.checkImageView.frame = self.bounds
+        self.checkLabel.frame = CGRect(x: 0, y: 5, width: self.bounds.width - 5, height: 20)
+      }
 
-    // MARK: - UICollectionViewDelegate, UICollectionViewDataSource methods
+    } /* DKImageCheckView */
 
-    override func collectionView(collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-		guard let selectedGroup = self.selectedGroupId else { return 0 }
-		
-		let group = getImageManager().groupDataManager.fetchGroupWithGroupId(selectedGroup)
-        return (group.totalCount ?? 0) + (self.hidesCamera ? 0 : 1)
+    private var asset: DKAsset!
+
+    private let thumbnailImageView: UIImageView = {
+      let thumbnailImageView = UIImageView()
+      thumbnailImageView.contentMode = .ScaleAspectFill
+      thumbnailImageView.clipsToBounds = true
+
+      return thumbnailImageView
+    }()
+
+    private let checkView = DKImageCheckView()
+
+    override var selected: Bool {
+      didSet {
+        checkView.hidden = !super.selected
+      }
     }
-    
-    override func collectionView(collectionView: UICollectionView, cellForItemAtIndexPath indexPath: NSIndexPath) -> UICollectionViewCell {
-        if indexPath.row == 0 && !self.hidesCamera {
-            return self.cameraCellForIndexPath(indexPath)
+
+    override init(frame: CGRect) {
+      super.init(frame: frame)
+
+      self.thumbnailImageView.frame = self.bounds
+      self.contentView.addSubview(self.thumbnailImageView)
+      self.contentView.addSubview(checkView)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+      super.layoutSubviews()
+
+      self.thumbnailImageView.frame = self.bounds
+      checkView.frame = self.thumbnailImageView.frame
+    }
+
+  } /* DKAssetCell */
+
+  class DKVideoAssetCell: DKAssetCell {
+
+    override var asset: DKAsset! {
+      didSet {
+        let videoDurationLabel = self.videoInfoView.viewWithTag(-1) as! UILabel
+        let minutes: Int = Int(asset.duration!) / 60
+        let seconds: Int = Int(asset.duration!) % 60
+        videoDurationLabel.text = String(format: "\(minutes):%02d", seconds)
+      }
+    }
+
+    override var selected: Bool {
+      didSet {
+        if super.selected {
+          self.videoInfoView.backgroundColor = UIColor(red: 20 / 255, green: 129 / 255, blue: 252 / 255, alpha: 1)
         } else {
-            return self.assetCellForIndexPath(indexPath)
+          self.videoInfoView.backgroundColor = UIColor(white: 0.0, alpha: 0.7)
         }
+      }
     }
-    
-    override func collectionView(collectionView: UICollectionView, shouldSelectItemAtIndexPath indexPath: NSIndexPath) -> Bool {
-        if let firstSelectedAsset = self.imagePickerController?.selectedAssets.first,
-            selectedAsset = (collectionView.cellForItemAtIndexPath(indexPath) as? DKAssetCell)?.asset
-            where self.imagePickerController?.allowMultipleTypes == false && firstSelectedAsset.isVideo != selectedAsset.isVideo {
-                
-                UIAlertView(title: DKImageLocalizedStringWithKey("selectPhotosOrVideos"),
-                    message: DKImageLocalizedStringWithKey("selectPhotosOrVideosError"),
-                    delegate: nil,
-                    cancelButtonTitle: DKImageLocalizedStringWithKey("ok")).show()
-                
-                return false
+
+    private lazy var videoInfoView: UIView = {
+      let videoInfoView = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 0))
+
+      let videoImageView = UIImageView(image: DKImageResource.videoCameraIcon())
+      videoInfoView.addSubview(videoImageView)
+      videoImageView.center = CGPoint(x: videoImageView.bounds.width / 2 + 7, y: videoInfoView.bounds.height / 2)
+      videoImageView.autoresizingMask = [.FlexibleBottomMargin, .FlexibleTopMargin]
+
+      let videoDurationLabel = UILabel()
+      videoDurationLabel.tag = -1
+      videoDurationLabel.textAlignment = .Right
+      videoDurationLabel.font = UIFont.systemFontOfSize(12)
+      videoDurationLabel.textColor = UIColor.whiteColor()
+      videoInfoView.addSubview(videoDurationLabel)
+      videoDurationLabel.frame = CGRect(x: 0, y: 0, width: videoInfoView.bounds.width - 7, height: videoInfoView.bounds.height)
+      videoDurationLabel.autoresizingMask = [.FlexibleWidth, .FlexibleHeight]
+
+      return videoInfoView
+    }()
+
+    override init(frame: CGRect) {
+      super.init(frame: frame)
+
+      self.contentView.addSubview(videoInfoView)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+
+    override func layoutSubviews() {
+      super.layoutSubviews()
+
+      let height: CGFloat = 30
+      self.videoInfoView.frame = CGRect(x: 0, y: self.contentView.bounds.height - height,
+        width: self.contentView.bounds.width, height: height)
+    }
+
+  } /* DKVideoAssetCell */
+
+  private lazy var selectGroupButton: UIButton = {
+    let button = UIButton()
+
+    let globalTitleColor = UINavigationBar.appearance().titleTextAttributes?[NSForegroundColorAttributeName] as? UIColor
+    button.setTitleColor(globalTitleColor ?? UIColor.blackColor(), forState: .Normal)
+
+    let globalTitleFont = UINavigationBar.appearance().titleTextAttributes?[NSFontAttributeName] as? UIFont
+    button.titleLabel!.font = globalTitleFont ?? UIFont.boldSystemFontOfSize(18.0)
+
+    button.addTarget(self, action: "showGroupSelector", forControlEvents: .TouchUpInside)
+    return button
+  }()
+
+  internal var selectedGroupId: String?
+
+  private var groupListVC: DKAssetGroupListVC!
+
+  private var hidesCamera :Bool = false
+
+  convenience init() {
+    let layout = DKAssetGroupGridLayout()
+    self.init(collectionViewLayout: layout)
+  }
+
+  override init(collectionViewLayout layout: UICollectionViewLayout) {
+    super.init(collectionViewLayout: layout)
+  }
+
+  private var currentViewSize: CGSize!
+  override func viewWillLayoutSubviews() {
+    super.viewWillLayoutSubviews()
+
+    if let currentViewSize = self.currentViewSize where CGSizeEqualToSize(currentViewSize, self.view.bounds.size) {
+      return
+    } else {
+      currentViewSize = self.view.bounds.size
+    }
+
+    let layout = DKAssetGroupGridLayout(contentSize: self.view.bounds.size)
+    self.collectionView!.setCollectionViewLayout(layout, animated: true) { completed in
+      self.collectionView!.reloadItemsAtIndexPaths(self.collectionView!.indexPathsForVisibleItems())
+    }
+  }
+
+  private lazy var groupImageRequestOptions: PHImageRequestOptions = {
+    let options = PHImageRequestOptions()
+    options.deliveryMode = .Opportunistic
+    options.resizeMode = .Exact;
+
+    return options
+  }()
+
+  required init?(coder aDecoder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+
+    let backgroundColor = overrideBackgroundColor ?? UIColor.whiteColor()
+    self.view.backgroundColor = backgroundColor
+
+    self.collectionView!.backgroundColor = overrideBackgroundColor
+    self.collectionView!.allowsMultipleSelection = true
+    self.collectionView!.registerClass(DKImageCameraCell.self, forCellWithReuseIdentifier: DKImageCameraIdentifier)
+    self.collectionView!.registerClass(DKAssetCell.self, forCellWithReuseIdentifier: DKImageAssetIdentifier)
+    self.collectionView!.registerClass(DKVideoAssetCell.self, forCellWithReuseIdentifier: DKVideoAssetIdentifier)
+
+    self.hidesCamera = !self.imagePickerController!.sourceType.contains(.Camera)
+    self.checkPhotoPermission()
+  }
+
+  internal func checkPhotoPermission() {
+    func photoDenied() {
+      self.view.addSubview(DKPermissionView.permissionView(.Photo))
+      self.collectionView?.hidden = true
+    }
+
+    func setup() {
+      getImageManager().groupDataManager.addObserver(self)
+      self.groupListVC = DKAssetGroupListVC(selectedGroupDidChangeBlock: { [unowned self] groupId in
+        self.selectAssetGroup(groupId)
+        }, defaultAssetGroup: self.imagePickerController?.defaultAssetGroup)
+      self.groupListVC.loadGroups()
+    }
+
+    DKImageManager.checkPhotoPermission { granted in
+      granted ? setup() : photoDenied()
+    }
+  }
+
+  func selectAssetGroup(groupId: String?) {
+    if self.selectedGroupId == groupId {
+      return
+    }
+
+    self.selectedGroupId = groupId
+    self.updateTitleView()
+    self.collectionView!.reloadData()
+  }
+
+  func updateTitleView() {
+    let group = getImageManager().groupDataManager.fetchGroupWithGroupId(self.selectedGroupId!)
+    self.title = group.groupName
+
+    let groupsCount = getImageManager().groupDataManager.groupIds?.count
+    self.selectGroupButton.setTitle(group.groupName + (groupsCount > 1 ? "  \u{25be}" : "" ), forState: .Normal)
+    self.selectGroupButton.sizeToFit()
+    self.selectGroupButton.enabled = groupsCount > 1
+
+    self.navigationItem.titleView = self.selectGroupButton
+  }
+
+  func showGroupSelector() {
+    DKPopoverViewController.popoverViewController(self.groupListVC, fromView: self.selectGroupButton)
+  }
+
+  // MARK: - Cells
+
+  func cameraCellForIndexPath(indexPath: NSIndexPath) -> UICollectionViewCell {
+    let cell = collectionView!.dequeueReusableCellWithReuseIdentifier(DKImageCameraIdentifier, forIndexPath: indexPath) as! DKImageCameraCell
+    if let cameraIcon = cameraIcon {
+      cell.cameraButton.setImage(cameraIcon, forState: .Normal)
+    }
+
+    cell.didCameraButtonClicked = { [unowned self] () in
+      if UIImagePickerController.isSourceTypeAvailable(.Camera) {
+        self.imagePickerController?.presentCamera()
+      }
+    }
+
+    return cell
+  }
+
+  func assetCellForIndexPath(indexPath: NSIndexPath) -> UICollectionViewCell {
+    let assetIndex = (indexPath.row - (self.hidesCamera ? 0 : 1))
+    let group = getImageManager().groupDataManager.fetchGroupWithGroupId(self.selectedGroupId!)
+
+    let asset = getImageManager().groupDataManager.fetchAssetWithGroup(group, index: assetIndex)
+
+    var cell: DKAssetCell!
+    var identifier: String!
+    if asset.isVideo {
+      identifier = DKVideoAssetIdentifier
+    } else {
+      identifier = DKImageAssetIdentifier
+    }
+
+    cell = self.collectionView!.dequeueReusableCellWithReuseIdentifier(identifier, forIndexPath: indexPath) as! DKAssetCell
+    cell.asset = asset
+    let tag = indexPath.row + 1
+    cell.tag = tag
+
+    let itemSize = self.collectionView!.collectionViewLayout.layoutAttributesForItemAtIndexPath(indexPath)!.size
+    asset.fetchImageWithSize(itemSize.toPixel(), options: self.groupImageRequestOptions) { image, info in
+      if cell.tag == tag {
+        cell.thumbnailImageView.image = image
+      }
+    }
+
+    if let index = self.imagePickerController!.selectedAssets.indexOf(asset) {
+      cell.selected = true
+      cell.checkView.checkLabel.text = "\(index + 1)"
+      self.collectionView!.selectItemAtIndexPath(indexPath, animated: false, scrollPosition: UICollectionViewScrollPosition.None)
+    } else {
+      cell.selected = false
+      self.collectionView!.deselectItemAtIndexPath(indexPath, animated: false)
+    }
+
+    return cell
+  }
+
+  // MARK: - UICollectionViewDelegate, UICollectionViewDataSource methods
+
+  override func collectionView(collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    guard let selectedGroup = self.selectedGroupId else { return 0 }
+
+    let group = getImageManager().groupDataManager.fetchGroupWithGroupId(selectedGroup)
+    return (group.totalCount ?? 0) + (self.hidesCamera ? 0 : 1)
+  }
+
+  override func collectionView(collectionView: UICollectionView, cellForItemAtIndexPath indexPath: NSIndexPath) -> UICollectionViewCell {
+    if indexPath.row == 0 && !self.hidesCamera {
+      return self.cameraCellForIndexPath(indexPath)
+    } else {
+      return self.assetCellForIndexPath(indexPath)
+    }
+  }
+
+  override func collectionView(collectionView: UICollectionView, shouldSelectItemAtIndexPath indexPath: NSIndexPath) -> Bool {
+    if let firstSelectedAsset = self.imagePickerController?.selectedAssets.first,
+      selectedAsset = (collectionView.cellForItemAtIndexPath(indexPath) as? DKAssetCell)?.asset
+      where self.imagePickerController?.allowMultipleTypes == false && firstSelectedAsset.isVideo != selectedAsset.isVideo {
+
+        UIAlertView(title: DKImageLocalizedStringWithKey("selectPhotosOrVideos"),
+          message: DKImageLocalizedStringWithKey("selectPhotosOrVideosError"),
+          delegate: nil,
+          cancelButtonTitle: DKImageLocalizedStringWithKey("ok")).show()
+
+        return false
+    }
+
+    return self.imagePickerController!.selectedAssets.count < self.imagePickerController!.maxSelectableCount
+  }
+
+  override func collectionView(collectionView: UICollectionView, didSelectItemAtIndexPath indexPath: NSIndexPath) {
+    let selectedAsset = (collectionView.cellForItemAtIndexPath(indexPath) as? DKAssetCell)?.asset
+    self.imagePickerController?.selectedImage(selectedAsset!)
+
+    let cell = collectionView.cellForItemAtIndexPath(indexPath) as! DKAssetCell
+    cell.checkView.checkLabel.text = "\(self.imagePickerController!.selectedAssets.count)"
+  }
+
+  override func collectionView(collectionView: UICollectionView, didDeselectItemAtIndexPath indexPath: NSIndexPath) {
+    if let removedAsset = (collectionView.cellForItemAtIndexPath(indexPath) as? DKAssetCell)?.asset {
+      let removedIndex = self.imagePickerController!.selectedAssets.indexOf(removedAsset)!
+
+      /// Minimize the number of cycles.
+      let indexPathsForSelectedItems = collectionView.indexPathsForSelectedItems() as [NSIndexPath]!
+      let indexPathsForVisibleItems = collectionView.indexPathsForVisibleItems()
+
+      let intersect = Set(indexPathsForVisibleItems).intersect(Set(indexPathsForSelectedItems))
+
+      for selectedIndexPath in intersect {
+        if let selectedCell = (collectionView.cellForItemAtIndexPath(selectedIndexPath) as? DKAssetCell) {
+          let selectedIndex = self.imagePickerController!.selectedAssets.indexOf(selectedCell.asset)!
+
+          if selectedIndex > removedIndex {
+            selectedCell.checkView.checkLabel.text = "\(Int(selectedCell.checkView.checkLabel.text!)! - 1)"
+          }
         }
-        
-        return self.imagePickerController!.selectedAssets.count < self.imagePickerController!.maxSelectableCount
+      }
+
+      self.imagePickerController?.unselectedImage(removedAsset)
     }
-    
-    override func collectionView(collectionView: UICollectionView, didSelectItemAtIndexPath indexPath: NSIndexPath) {
-		let selectedAsset = (collectionView.cellForItemAtIndexPath(indexPath) as? DKAssetCell)?.asset
-		self.imagePickerController?.selectedImage(selectedAsset!)
-        
-		let cell = collectionView.cellForItemAtIndexPath(indexPath) as! DKAssetCell
-		cell.checkView.checkLabel.text = "\(self.imagePickerController!.selectedAssets.count)"
+  }
+
+  // MARK: - DKGroupDataManagerObserver methods
+
+  func groupDidUpdate(groupId: String) {
+    if self.selectedGroupId == groupId {
+      self.updateTitleView()
     }
-    
-    override func collectionView(collectionView: UICollectionView, didDeselectItemAtIndexPath indexPath: NSIndexPath) {
-		if let removedAsset = (collectionView.cellForItemAtIndexPath(indexPath) as? DKAssetCell)?.asset {
-			let removedIndex = self.imagePickerController!.selectedAssets.indexOf(removedAsset)!
-			
-			/// Minimize the number of cycles.
-			let indexPathsForSelectedItems = collectionView.indexPathsForSelectedItems() as [NSIndexPath]!
-			let indexPathsForVisibleItems = collectionView.indexPathsForVisibleItems()
-			
-			let intersect = Set(indexPathsForVisibleItems).intersect(Set(indexPathsForSelectedItems))
-			
-			for selectedIndexPath in intersect {
-				if let selectedCell = (collectionView.cellForItemAtIndexPath(selectedIndexPath) as? DKAssetCell) {
-					let selectedIndex = self.imagePickerController!.selectedAssets.indexOf(selectedCell.asset)!
-					
-					if selectedIndex > removedIndex {
-						selectedCell.checkView.checkLabel.text = "\(Int(selectedCell.checkView.checkLabel.text!)! - 1)"
-					}
-				}
-			}
-			
-			self.imagePickerController?.unselectedImage(removedAsset)
-		}
+  }
+
+  func group(groupId: String, didRemoveAssets assets: [DKAsset]) {
+    if let imagePickerController = self.imagePickerController {
+      for (_, selectedAsset) in imagePickerController.selectedAssets.enumerate() {
+        for removedAsset in assets {
+          if selectedAsset.isEqual(removedAsset) {
+            imagePickerController.unselectedImage(selectedAsset)
+          }
+        }
+      }
+      if self.selectedGroupId == groupId {
+        self.collectionView?.reloadData()
+      }
     }
-	
-	// MARK: - DKGroupDataManagerObserver methods
-	
-	func groupDidUpdate(groupId: String) {
-		if self.selectedGroupId == groupId {
-			self.updateTitleView()
-		}
-	}
-	
-	func group(groupId: String, didRemoveAssets assets: [DKAsset]) {
-		if let imagePickerController = self.imagePickerController {
-			for (_, selectedAsset) in imagePickerController.selectedAssets.enumerate() {
-				for removedAsset in assets {
-					if selectedAsset.isEqual(removedAsset) {
-						imagePickerController.unselectedImage(selectedAsset)
-					}
-				}
-			}
-			if self.selectedGroupId == groupId {
-				self.collectionView?.reloadData()
-			}
-		}
-	}
-	
-	func group(groupId: String, didInsertAssets assets: [DKAsset]) {
-		self.collectionView?.reloadData()
-	}
+  }
+
+  func group(groupId: String, didInsertAssets assets: [DKAsset]) {
+    self.collectionView?.reloadData()
+  }
 
 }


### PR DESCRIPTION
Looks like a lot of changes, but they're actually code formation since previously the indentions had lots of issues.

The core changes are:
1. Added a cameraIcon property which will be used in the camera cell
2. Added a overrideBackgroundColor property to customize the picker background color

Thanks for the component!