### PR TITLE
Develop

### DIFF
--- a/DKImagePickerController/DKImagePickerController.swift
+++ b/DKImagePickerController/DKImagePickerController.swift
@@ -292,10 +292,11 @@ public class DKImagePickerController : UINavigationController {
 	private func createCamera() -> UIViewController {
 		
 		let didCancel = { () in
-			if self.viewControllers.count == 0 {
-				self.dismissViewControllerAnimated(true, completion: nil);
-			}
-			self.dismiss()
+            if self.presentedViewController != nil {
+                self.dismissViewControllerAnimated(true, completion: nil)
+            }else {
+                self.dismiss()
+            }
 		}
 		
 		let didFinishCapturingImage = { (image: UIImage) in

--- a/DKImagePickerController/DKImagePickerController.swift
+++ b/DKImagePickerController/DKImagePickerController.swift
@@ -161,7 +161,6 @@ public class DKImagePickerController : UINavigationController {
 			if let rootVC = self.viewControllers.first as? DKAssetGroupDetailVC {
 				rootVC.collectionView?.reloadData()
 			}
-			self.updateDoneButtonTitle()
         }
     }
     
@@ -376,14 +375,11 @@ public class DKImagePickerController : UINavigationController {
 			self.done()
 		} else if self.singleSelect {
 			self.done()
-		} else {
-			updateDoneButtonTitle()
 		}
 	}
 	
 	internal func unselectedImage(asset: DKAsset) {
 		selectedAssets.removeAtIndex(selectedAssets.indexOf(asset)!)
-		updateDoneButtonTitle()
 	}
 	
     // MARK: - Handles Orientation

--- a/DKImagePickerController/View/DKAssetGroupDetailVC.swift
+++ b/DKImagePickerController/View/DKAssetGroupDetailVC.swift
@@ -305,15 +305,21 @@ internal class DKAssetGroupDetailVC: UICollectionViewController, DKGroupDataMana
     func cameraCellForIndexPath(indexPath: NSIndexPath) -> UICollectionViewCell {
         let cell = collectionView!.dequeueReusableCellWithReuseIdentifier(DKImageCameraIdentifier, forIndexPath: indexPath) as! DKImageCameraCell
         
-        cell.didCameraButtonClicked = {
+        cell.didCameraButtonClicked = { [unowned self] in 
             if UIImagePickerController.isSourceTypeAvailable(.Camera) &&
             DKImagePickerController.sharedInstance().selectedAssets.count < DKImagePickerController.sharedInstance().maxSelectableCount {
                 DKImagePickerController.sharedInstance().presentCamera()
+            }else {
+                self.showMaxPhotosSelectedAlertView()
             }
         }
 
         return cell
 	}
+    
+    private func showMaxPhotosSelectedAlertView() {
+        UIAlertView(title: "Max photos limit reached", message: "You can select \(DKImagePickerController.sharedInstance().maxSelectableCount) photos", delegate: nil, cancelButtonTitle: "OK").show()
+    }
 	
 	func assetCellForIndexPath(indexPath: NSIndexPath) -> UICollectionViewCell {
 		let assetIndex = (indexPath.row - (self.hidesCamera ? 0 : 1))
@@ -383,7 +389,11 @@ internal class DKAssetGroupDetailVC: UICollectionViewController, DKGroupDataMana
                 return false
         }
         
-        return DKImagePickerController.sharedInstance().selectedAssets.count < DKImagePickerController.sharedInstance().maxSelectableCount
+        let shouldSelect = DKImagePickerController.sharedInstance().selectedAssets.count < DKImagePickerController.sharedInstance().maxSelectableCount
+        if !shouldSelect {
+            showMaxPhotosSelectedAlertView()
+        }
+        return shouldSelect
     }
     
     override func collectionView(collectionView: UICollectionView, didSelectItemAtIndexPath indexPath: NSIndexPath) {

--- a/DKImagePickerController/View/DKAssetGroupDetailVC.swift
+++ b/DKImagePickerController/View/DKAssetGroupDetailVC.swift
@@ -306,7 +306,8 @@ internal class DKAssetGroupDetailVC: UICollectionViewController, DKGroupDataMana
         let cell = collectionView!.dequeueReusableCellWithReuseIdentifier(DKImageCameraIdentifier, forIndexPath: indexPath) as! DKImageCameraCell
         
         cell.didCameraButtonClicked = {
-            if UIImagePickerController.isSourceTypeAvailable(.Camera) {
+            if UIImagePickerController.isSourceTypeAvailable(.Camera) &&
+            DKImagePickerController.sharedInstance().selectedAssets.count < DKImagePickerController.sharedInstance().maxSelectableCount {
                 DKImagePickerController.sharedInstance().presentCamera()
             }
         }

--- a/DKImagePickerControllerDemo.xcodeproj/project.pbxproj
+++ b/DKImagePickerControllerDemo.xcodeproj/project.pbxproj
@@ -269,7 +269,6 @@
 				TargetAttributes = {
 					9C35CBFE19DBB00700557269 = {
 						CreatedOnToolsVersion = 6.0;
-						DevelopmentTeam = E39GW2L428;
 					};
 					9CF72B101B8F073400238B9A = {
 						CreatedOnToolsVersion = 6.4;


### PR DESCRIPTION
I have fixed some minor issues that i came across
When dismissing camera which was presented from DKAssetGroupDetailVC, it actually dismisses the DetailVC whe in actual it should only dismiss camera. Its frustrating as it causes to lose track of all the selected images.
secondly you were able to bypass the maxSelectableCount if you select max selectable photos and then click camera.
Have a look at the changes and see if they are okay to be merged