### PR TITLE
Fix bug: view controller should be reinitialized when source type changed in scenario of sharing instance

### DIFF
--- a/DKImagePickerController/DKImagePickerController.swift
+++ b/DKImagePickerController/DKImagePickerController.swift
@@ -149,7 +149,13 @@ public class DKImagePickerController : UINavigationController {
 	}
 	
     /// If sourceType is Camera will cause the assetType & maxSelectableCount & allowMultipleTypes & defaultSelectedAssets to be ignored.
-    public var sourceType: DKImagePickerControllerSourceType = .Both
+    public var sourceType: DKImagePickerControllerSourceType = .Both {
+        didSet { /// If source type changed in the scenario of sharing instance, view controller should be reinitialized.
+            if(oldValue != sourceType) {
+                self.hasInitialized = false
+            }
+        }
+    }
     
     /// Whether allows to select photos and videos at the same time.
     public var allowMultipleTypes = true
@@ -238,6 +244,7 @@ public class DKImagePickerController : UINavigationController {
 					self.setViewControllers([camera], animated: false)
 				}
 			} else {
+                self.navigationBarHidden = false
 				let rootVC = DKAssetGroupDetailVC()
 				self.updateCancelButtonForVC(rootVC)
 				self.setViewControllers([rootVC], animated: false)


### PR DESCRIPTION

Issue description:
After view controller initialized once, the member named
'hasInitialized' will be set with value 'true' and no change to be update
again even though source type changed. That will cause unexpected view
shown to user. e.g. using same instance, user get photo from camera,
then get photo from album, the camera will be shown but the photo picker.

Solution description:
1. Monitor source type change by 'didSet', if source type changed, set
'hasInitialized' with false, the view controller will force to
initialize again before shown to user.
2. Set navigation bar hidden with false for scenario pick photo from
album or both, or else navigation bar nature maybe inherit from last
initialize.