### PR TITLE
Make the init of DKAsset as public.

### DIFF
--- a/DKImageManager/Data/Model/DKAsset.swift
+++ b/DKImageManager/Data/Model/DKAsset.swift
@@ -32,7 +32,7 @@ public class DKAsset: NSObject {
 	
 	public private(set) var originalAsset: PHAsset?
 		
-	init(originalAsset: PHAsset) {
+	public init(originalAsset: PHAsset) {
 		super.init()
 		
 		self.originalAsset = originalAsset


### PR DESCRIPTION
I'm trying to save/restore the selected assets via NSCoding interface.

Due to the *PHAsset* does not conform with NSCoding, I have to store its `localIdentify`. Then I would like recreate the *DKAsset* by the original *PHAsset* when loading it from archive data.