### PR TITLE
camera become chaos when autorotating

### DIFF
--- a/DKImagePickerController/DKImagePickerController.swift
+++ b/DKImagePickerController/DKImagePickerController.swift
@@ -434,7 +434,7 @@ public class DKImagePickerController : UINavigationController {
     // MARK: - Handles Orientation
 
     public override func shouldAutorotate() -> Bool {
-		return self.allowsLandscape ? true : false
+		return self.allowsLandscape && self.sourceType != .Camera ? true : false
     }
     
     public override func supportedInterfaceOrientations() -> UIInterfaceOrientationMask {


### PR DESCRIPTION
The main demo has separated  allowsLandscape and take a picture
functions which will omit the chaos when both are invoked. When I set
the allowsLandscape = true and take a photo, the camera would rotate
automatically to cause the performance wrong and part of the camera view is 
covered underground to have no way to take a photo.
My solution is getting rid of the Camera sourceType when trying to
autorotate. It seems work fine.
Hope to help someone. And I have learned a lot from author.