### PR TITLE
Fix crash when denied access

### DIFF
--- a/DKImageManager/Data/Model/DKAsset.swift
+++ b/DKImageManager/Data/Model/DKAsset.swift
@@ -32,13 +32,14 @@ open class DKAsset: NSObject {
 	
 	open private(set) var originalAsset: PHAsset?
     
-    open var localIdentifier: String!
+    open var localIdentifier: String
 		
 	public init(originalAsset: PHAsset) {
+        self.localIdentifier = originalAsset.localIdentifier
+        
 		super.init()
 		
 		self.originalAsset = originalAsset
-        self.localIdentifier = originalAsset.localIdentifier
 		
 		let assetType = originalAsset.mediaType
 		if assetType == .video {
@@ -49,17 +50,19 @@ open class DKAsset: NSObject {
 	
 	private var image: UIImage?
 	internal init(image: UIImage) {
+        self.localIdentifier = String(image.hash)
+        
 		super.init()
         
 		self.image = image
 		self.fullScreenImage = (image, nil)
-        self.localIdentifier = String(image.hash)
 	}
 	
 	override open func isEqual(_ object: Any?) -> Bool {
-		let another = object! as! DKAsset
-		
-        return self.localIdentifier == another.localIdentifier
+        if let another = object as? DKAsset {
+            return self.localIdentifier == another.localIdentifier
+        }
+        return false
 	}
 	
 	public func fetchImageWithSize(_ size: CGSize, completeBlock: @escaping (_ image: UIImage?, _ info: [AnyHashable: Any]?) -> Void) {
@@ -74,7 +77,7 @@ open class DKAsset: NSObject {
 		if let _ = self.originalAsset {
 			getImageManager().fetchImageForAsset(self, size: size, options: options, contentMode: contentMode, completeBlock: completeBlock)
 		} else {
-			completeBlock(self.image!, nil)
+			completeBlock(self.image, nil)
 		}
 	}
 	
@@ -124,7 +127,10 @@ open class DKAsset: NSObject {
 		options.isSynchronous = sync
 		
 		getImageManager().fetchImageDataForAsset(self, options: options, completeBlock: { (data, info) in
-			let image = UIImage(data: data!)
+            var image: UIImage?
+            if let data = data {
+    			image = UIImage(data: data)
+            }
 			completeBlock(image, info)
 		})
 	}
@@ -198,9 +204,11 @@ public extension DKAsset {
      - parameter presetName:    An NSString specifying the name of the preset template for the export. See AVAssetExportPresetXXX.
      */
 	public func writeAVToFile(_ path: String, presetName: String, completeBlock: @escaping (_ success: Bool) -> Void) {
-		self.fetchAVAsset(nil) { (AVAsset, _) in
+		self.fetchAVAsset(nil) { (avAsset, _) in
 			DKAssetWriter.writeQueue.addOperation({
-				if let exportSession = AVAssetExportSession(asset: AVAsset!, presetName: presetName) {
+                if let avAsset = avAsset,
+                    let exportSession = AVAssetExportSession(asset: avAsset, presetName: presetName)
+                {
 					exportSession.outputFileType = AVFileTypeQuickTimeMovie
 					exportSession.outputURL = URL(fileURLWithPath: path)
 					exportSession.shouldOptimizeForNetworkUse = true

--- a/DKImageManager/Data/Model/DKAsset.swift
+++ b/DKImageManager/Data/Model/DKAsset.swift
@@ -35,7 +35,7 @@ open class DKAsset: NSObject {
     open var localIdentifier: String
 		
 	public init(originalAsset: PHAsset) {
-        self.localIdentifier = originalAsset.localIdentifier
+        	localIdentifier = originalAsset.localIdentifier
         
 		super.init()
 		

--- a/DKImagePickerController/View/DKAssetGroupDetailVC.swift
+++ b/DKImagePickerController/View/DKAssetGroupDetailVC.swift
@@ -258,8 +258,6 @@ internal class DKAssetGroupDetailVC: UIViewController, UICollectionViewDelegate,
 		
 		self.hidesCamera = self.imagePickerController.sourceType == .photo
 		self.checkPhotoPermission()
-        
-        self.resetCachedAssets()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -288,6 +286,7 @@ internal class DKAssetGroupDetailVC: UIViewController, UICollectionViewDelegate,
 		}
 		
 		func setup() {
+            self.resetCachedAssets()
 			getImageManager().groupDataManager.addObserver(self)
 			self.groupListVC = DKAssetGroupListVC(selectedGroupDidChangeBlock: { [unowned self] groupId in
 				self.selectAssetGroup(groupId)


### PR DESCRIPTION
The resetCachedAssets > stopCachingForAllAssets needs access and would crash the app.

Also removed some ! usage in DKAsset.swift, which were either unsafe or unnecessary
