### PR TITLE
fixed crash while selecting/deselecting assets

### DIFF
--- a/DKImagePickerController/View/DKAssetGroupDetailVC.swift
+++ b/DKImagePickerController/View/DKAssetGroupDetailVC.swift
@@ -289,9 +289,9 @@ internal class DKAssetGroupDetailVC: UIViewController, UICollectionViewDelegate,
 			let intersect = Set(indexPathsForVisibleItems).intersection(Set(indexPathsForSelectedItems))
 			
 			for selectedIndexPath in intersect {
-				if let selectedCell = (collectionView.cellForItem(at: selectedIndexPath) as? DKAssetGroupDetailBaseCell) {
-					let selectedIndex = self.imagePickerController.selectedAssets.index(of: selectedCell.asset)!
-					
+				if let selectedCell = (collectionView.cellForItem(at: selectedIndexPath) as? DKAssetGroupDetailBaseCell),
+					let selectedIndex = self.imagePickerController.selectedAssets.index(of: selectedCell.asset) {
+						
 					if selectedIndex > removedIndex {
 						selectedCell.index = selectedCell.index - 1
 					}


### PR DESCRIPTION
Hi. I found the library was crashing on the forced unwrapping of selectedIndex while selecting/deselecting assets. This seems to fix the issue.