### PR TITLE
fix Swift compiler warning - removed deprecated calls

### DIFF
--- a/DKCamera/DKCamera.swift
+++ b/DKCamera/DKCamera.swift
@@ -685,13 +685,13 @@ public extension UIDeviceOrientation {
         case .portrait:
             return 0
         case .portraitUpsideDown:
-            return CGFloat(M_PI)
+            return CGFloat.pi
         case .landscapeRight:
-            return CGFloat(-M_PI_2)
+            return -CGFloat.pi / 2.0
         case .landscapeLeft:
-            return CGFloat(M_PI_2)
+            return CGFloat.pi / 2.0
         default:
-            return 0
+            return 0.0
         }
     }
     


### PR DESCRIPTION
removed deprecated calls: M_PI, M_PI_2