### PR TITLE
Allow subclassing of DKAssetGroupDetailVC, so the title can be set by…

### DIFF
--- a/DKImagePickerController/DKImagePickerController.swift
+++ b/DKImagePickerController/DKImagePickerController.swift
@@ -206,7 +206,7 @@ open class DKImagePickerController : UINavigationController {
     public var didCancel: (() -> Void)?
     public var showsCancelButton = false {
         didSet {
-            if let rootVC =  self.viewControllers.first {
+            if let rootVC = self.viewControllers.first {
                 self.updateCancelButtonForVC(rootVC)
             }
         }
@@ -272,7 +272,7 @@ open class DKImagePickerController : UINavigationController {
                 }
             } else {
                 self.isNavigationBarHidden = false
-                let rootVC = DKAssetGroupDetailVC()
+                let rootVC = self.makeRootVC()
                 rootVC.imagePickerController = self
                 
                 self.UIDelegate.prepareLayout(self, vc: rootVC)
@@ -289,6 +289,10 @@ open class DKImagePickerController : UINavigationController {
         let assetFetchOptions = PHFetchOptions()
         return assetFetchOptions
     }()
+  
+    open func makeRootVC() -> DKAssetGroupDetailVC {
+      return DKAssetGroupDetailVC()
+    }
     
     private func createAssetFetchOptions() -> PHFetchOptions? {
         let createImagePredicate = { () -> NSPredicate in

--- a/DKImagePickerController/View/DKAssetGroupDetailVC.swift
+++ b/DKImagePickerController/View/DKAssetGroupDetailVC.swift
@@ -25,9 +25,9 @@ private extension UICollectionView {
 }
 
 // Show all images in the asset group
-internal class DKAssetGroupDetailVC: UIViewController, UICollectionViewDelegate, UICollectionViewDataSource, DKGroupDataManagerObserver {
+open class DKAssetGroupDetailVC: UIViewController, UICollectionViewDelegate, UICollectionViewDataSource, DKGroupDataManagerObserver {
     	
-    private lazy var selectGroupButton: UIButton = {
+    public lazy var selectGroupButton: UIButton = {
         let button = UIButton()
 		
 		let globalTitleColor = UINavigationBar.appearance().titleTextAttributes?[NSForegroundColorAttributeName] as? UIColor
@@ -42,7 +42,7 @@ internal class DKAssetGroupDetailVC: UIViewController, UICollectionViewDelegate,
 		
     internal var collectionView: UICollectionView!
     internal weak var imagePickerController: DKImagePickerController!
-    private var selectedGroupId: String?
+    public var selectedGroupId: String?
 	private var groupListVC: DKAssetGroupListVC!
     private var hidesCamera: Bool = false
 	private var footerView: UIView?
@@ -50,7 +50,7 @@ internal class DKAssetGroupDetailVC: UIViewController, UICollectionViewDelegate,
     private var registeredCellIdentifiers = Set<String>()
     private var thumbnailSize = CGSize.zero
 	
-	override func viewWillLayoutSubviews() {
+	override open func viewWillLayoutSubviews() {
 		super.viewWillLayoutSubviews()
 		
 		if let currentViewSize = self.currentViewSize, currentViewSize.equalTo(self.view.bounds.size) {
@@ -62,7 +62,7 @@ internal class DKAssetGroupDetailVC: UIViewController, UICollectionViewDelegate,
 		self.collectionView?.collectionViewLayout.invalidateLayout()
 	}
     
-    override func viewDidLoad() {
+    override open func viewDidLoad() {
         super.viewDidLoad()
 		
 		let layout = self.imagePickerController.UIDelegate.layoutForImagePickerController(self.imagePickerController).init()
@@ -82,13 +82,13 @@ internal class DKAssetGroupDetailVC: UIViewController, UICollectionViewDelegate,
 		self.checkPhotoPermission()
     }
     
-    override func viewDidAppear(_ animated: Bool) {
+    override open func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
         self.updateCachedAssets()
     }
 	
-	override func viewDidLayoutSubviews() {
+	override open func viewDidLayoutSubviews() {
 		super.viewDidLayoutSubviews()
 		
 		if let footerView = self.footerView {
@@ -132,7 +132,7 @@ internal class DKAssetGroupDetailVC: UIViewController, UICollectionViewDelegate,
 		self.collectionView!.reloadData()
     }
 	
-	func updateTitleView() {
+	open func updateTitleView() {
 		let group = getImageManager().groupDataManager.fetchGroupWithGroupId(self.selectedGroupId!)
 		self.title = group.groupName
 		
@@ -224,14 +224,14 @@ internal class DKAssetGroupDetailVC: UIViewController, UICollectionViewDelegate,
 
     // MARK: - UICollectionViewDelegate, UICollectionViewDataSource methods
 
-    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+    public func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
 		guard let selectedGroupId = self.selectedGroupId else { return 0 }
 		
 		let group = getImageManager().groupDataManager.fetchGroupWithGroupId(selectedGroupId)
         return (group.totalCount ?? 0) + (self.hidesCamera ? 0 : 1)
     }
     
-    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+    public func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         let cell: DKAssetGroupDetailBaseCell!
         if self.isCameraCell(indexPath: indexPath) {
             cell = self.dequeueReusableCameraCell(for: indexPath)
@@ -242,7 +242,7 @@ internal class DKAssetGroupDetailVC: UIViewController, UICollectionViewDelegate,
         return cell
     }
     
-    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+    public func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
         if let firstSelectedAsset = self.imagePickerController.selectedAssets.first,
             let selectedAsset = (collectionView.cellForItem(at: indexPath) as? DKAssetGroupDetailBaseCell)?.asset, self.imagePickerController.allowMultipleTypes == false && firstSelectedAsset.isVideo != selectedAsset.isVideo {
 
@@ -264,7 +264,7 @@ internal class DKAssetGroupDetailVC: UIViewController, UICollectionViewDelegate,
 		return shouldSelect
     }
     
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+    public func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         if self.isCameraCell(indexPath: indexPath) {
             if UIImagePickerController.isSourceTypeAvailable(.camera) {
                 self.imagePickerController.presentCamera()
@@ -279,7 +279,7 @@ internal class DKAssetGroupDetailVC: UIViewController, UICollectionViewDelegate,
         }
     }
     
-    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+    public func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
 		if let removedAsset = (collectionView.cellForItem(at: indexPath) as? DKAssetGroupDetailBaseCell)?.asset {
 			let removedIndex = self.imagePickerController.selectedAssets.index(of: removedAsset)!
 			
@@ -301,7 +301,7 @@ internal class DKAssetGroupDetailVC: UIViewController, UICollectionViewDelegate,
 		}
     }
     
-    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    public func scrollViewDidScroll(_ scrollView: UIScrollView) {
         self.updateCachedAssets()
     }
     


### PR DESCRIPTION
… the subclass.

I'm not crazy about how many things I had to change to "open" to make this work, but here it is. It's unfortunate to open up the whole DKAssetGroupDetailVC class when it seems like there's really only one method someone might want to change.