### PR TITLE
Fix- photoLibraryDidChange method crash when photo was deleted from c…

### DIFF
--- a/DKImageManager/Data/DKGroupDataManager.swift
+++ b/DKImageManager/Data/DKGroupDataManager.swift
@@ -168,11 +168,10 @@ public class DKGroupDataManager: DKBaseManager, PHPhotoLibraryChangeObserver {
     
     // MARK: - PHPhotoLibraryChangeObserver methods
     
-    public func photoLibraryDidChange(_ changeInstance: PHChange) {        
-        guard (self.groups?.values) != nil else {
-            return
-        }
-        for group in self.groups!.values {
+    public func photoLibraryDidChange(_ changeInstance: PHChange) {
+        guard let groups = self.groups?.values else { return  }
+        
+        for group in groups {
             if let changeDetails = changeInstance.changeDetails(for: group.originalCollection) {
                 if changeDetails.objectWasDeleted {
                     self.groups![group.groupId] = nil

--- a/DKImageManager/Data/DKGroupDataManager.swift
+++ b/DKImageManager/Data/DKGroupDataManager.swift
@@ -168,7 +168,10 @@ public class DKGroupDataManager: DKBaseManager, PHPhotoLibraryChangeObserver {
     
     // MARK: - PHPhotoLibraryChangeObserver methods
     
-    public func photoLibraryDidChange(_ changeInstance: PHChange) {
+    public func photoLibraryDidChange(_ changeInstance: PHChange) {        
+        guard (self.groups?.values) != nil else {
+            return
+        }
         for group in self.groups!.values {
             if let changeDetails = changeInstance.changeDetails(for: group.originalCollection) {
                 if changeDetails.objectWasDeleted {


### PR DESCRIPTION
Thank you so much for this wonderful library.You really did a great job for developer community.

I am using your library in my project.I found one issue 

Here are the steps to reproduce the issue:

Setup- user does not have any pictures/videos on their device

In the  app, user is on the image picker - there are no pictures/videos available to be selected
User goes to the camera app and takes a photo
User returns to the  app.

Then,photoLibraryDidChange did fires and return self.groups?.values nil value ,But, we are trying to force  unwrap self.groups!.values.So App crashes.

Issue:  App crashes upon resumption of the app