### PR TITLE
Fix crash when user forbids access to camera

### DIFF
--- a/DKCamera/DKCamera.swift
+++ b/DKCamera/DKCamera.swift
@@ -394,9 +394,10 @@ open class DKCamera: UIViewController, AVCaptureMetadataOutputObjectsDelegate {
                 self.captureSession.removeInput(oldInput)
             }
             
-            let frontInput = try? AVCaptureDeviceInput(device: self.currentDevice!)
-            if self.captureSession.canAddInput(frontInput!) {
-                self.captureSession.addInput(frontInput!)
+            if let frontInput = try? AVCaptureDeviceInput(device: currentDevice) {
+                if self.captureSession.canAddInput(frontInput) {
+                    self.captureSession.addInput(frontInput)
+                }
             }
             
             try! currentDevice.lockForConfiguration()


### PR DESCRIPTION
If user has granted access to gallery but has forbidden access to camera, the app will crash when he taps on camera cell