### PR TITLE
Fixed a crash on camera controller

### DIFF
--- a/DKImagePickerController/DKImagePickerController.swift
+++ b/DKImagePickerController/DKImagePickerController.swift
@@ -360,11 +360,13 @@ open class DKImagePickerController : UINavigationController {
         }
         
         let didFinishCapturingImage = { [unowned self] (image: UIImage, metadata: [AnyHashable : Any]?) in
-            self.capturingImage(image, metadata, { [unowned self] (asset) in
-                if self.sourceType != .camera {
-                    self.dismissCamera()
+            self.capturingImage(image, metadata, { [weak self] (asset) in
+                if let strongSelf = self {
+                    if strongSelf.sourceType != .camera {
+                        strongSelf.dismissCamera()
+                    }
+                    strongSelf.selectImage(asset)
                 }
-                self.selectImage(asset)
             })
         }
         


### PR DESCRIPTION
If capture button is pressed multiple times in quick succession, the camera crashes the app. This happens on older devices e.g. iPhone 5

Reason is the 'unowned' self which has been deallocated after the first capture. So it crashes on any subsequent capture calls.