### PR TITLE
Fixes assetType in the "Inline" case for example app

### DIFF
--- a/Example/DKImagePickerControllerDemo/DKImagePickerControllerDemoVC.swift
+++ b/Example/DKImagePickerControllerDemo/DKImagePickerControllerDemoVC.swift
@@ -12,6 +12,12 @@ import Photos
 
 class DKImagePickerControllerDemoVC: UITableViewController {
     
+    fileprivate func imageOnlyAssetFetchOptions() -> PHFetchOptions {
+        let assetFetchOptions = PHFetchOptions()
+        assetFetchOptions.predicate = NSPredicate(format: "mediaType == %d", PHAssetMediaType.image.rawValue)
+        return assetFetchOptions
+    }
+    
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         let cell = sender as! UITableViewCell
         
@@ -108,13 +114,16 @@ class DKImagePickerControllerDemoVC: UITableViewController {
             let groupDataManagerConfiguration = DKImageGroupDataManagerConfiguration()
             groupDataManagerConfiguration.fetchLimit = 10
             groupDataManagerConfiguration.assetGroupTypes = [.smartAlbumUserLibrary]
+            // To specify photos only, we'd typically use pickerController.assetType = .allPhotos.
+            // Because we're specifying a custom DKImageGroupDataManager, that doesn't work,
+            // and we have to specify it using assetFetchOptions.
+            groupDataManagerConfiguration.assetFetchOptions = imageOnlyAssetFetchOptions()
             
             let groupDataManager = DKImageGroupDataManager(configuration: groupDataManagerConfiguration)
             
             let pickerController = DKImagePickerController(groupDataManager: groupDataManager)
             pickerController.inline = true
             pickerController.UIDelegate = CustomInlineLayoutUIDelegate()
-            pickerController.assetType = .allPhotos
             pickerController.sourceType = .photo
             
             destination.pickerController = pickerController


### PR DESCRIPTION
The "Inline" case was using pickerController.assetType to specify photos only; but because it had a custom DKImageGroupDataManager, .assetType didn't do anything. This moves the "photos only" specification to where it will work.

As an aside, this is kind of the "band-aid" fix: it shows people how to do it, but it still leaves the confusing possibility that someone will use assetType and it won't do anything. Any thoughts on whether I should implement it better, and if so, how?