### PR TITLE
Fixed memory Leaks

### DIFF
--- a/Sources/DKImagePickerController/DKImagePickerController.swift
+++ b/Sources/DKImagePickerController/DKImagePickerController.swift
@@ -111,7 +111,7 @@ open class DKImagePickerController: UINavigationController, DKImageBaseManagerOb
     @objc public var selectedChanged: (() -> Void)?
 
     /// Colors applied to the permission view when access needs to be granted by the user
-    @objc public var permissionViewColors = DKPermissionViewColors()
+    @objc public lazy var permissionViewColors = DKPermissionViewColors()
     
     /// A Bool value indicating whether to allow the picker to auto-export the selected assets to the specified directory when done is called.
     /// picker will creating a default exporter if exportsWhenCompleted is true and the exporter is nil.
@@ -155,7 +155,7 @@ open class DKImagePickerController: UINavigationController, DKImageBaseManagerOb
         return DKImageExtensionController(imagePickerController: self)
     }()
     
-    internal var proxyObserver = DKImageBaseManager()
+    internal lazy var proxyObserver = DKImageBaseManager()
     
     private weak var rootVC: (UIViewController & DKImagePickerControllerAware)?
     

--- a/Sources/DKImagePickerController/DKImagePickerController.swift
+++ b/Sources/DKImagePickerController/DKImagePickerController.swift
@@ -111,7 +111,7 @@ open class DKImagePickerController: UINavigationController, DKImageBaseManagerOb
     @objc public var selectedChanged: (() -> Void)?
 
     /// Colors applied to the permission view when access needs to be granted by the user
-    @objc public lazy var permissionViewColors = DKPermissionViewColors()
+    @objc public var permissionViewColors = DKPermissionViewColors()
     
     /// A Bool value indicating whether to allow the picker to auto-export the selected assets to the specified directory when done is called.
     /// picker will creating a default exporter if exportsWhenCompleted is true and the exporter is nil.
@@ -155,37 +155,16 @@ open class DKImagePickerController: UINavigationController, DKImageBaseManagerOb
         return DKImageExtensionController(imagePickerController: self)
     }()
     
-    internal lazy var proxyObserver = DKImageBaseManager()
+    internal var proxyObserver = DKImageBaseManager()
     
     private weak var rootVC: (UIViewController & DKImagePickerControllerAware)?
     
-    public convenience init() {
-        let rootVC = UIViewController()
+    public convenience init(groupDataManager: DKImageGroupDataManager? = nil) {
+        self.init(nibName: nil, bundle: nil)
         
-        self.init(rootViewController: rootVC)
-    }
-    
-    public convenience init(groupDataManager: DKImageGroupDataManager) {
-        let rootVC = UIViewController()
-        self.init(rootViewController: rootVC)
-        
-        self.groupDataManager = groupDataManager
-    }
-    
-    public override init(rootViewController: UIViewController) {
-        super.init(rootViewController: rootViewController)
-        
-        self.preferredContentSize = CGSize(width: 680, height: 600)
-        
-        rootViewController.navigationItem.hidesBackButton = true
-    }
-    
-    public override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
-        super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-    }
-    
-    required public init?(coder aDecoder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        if let groupDataManager = groupDataManager {
+            self.groupDataManager = groupDataManager            
+        }
     }
     
     deinit {
@@ -222,6 +201,12 @@ open class DKImagePickerController: UINavigationController, DKImageBaseManagerOb
         if self.selectedAssetIdentifiers.count > 0 {
             self.UIDelegate.imagePickerController(self, didSelectAssets: self.selectedAssets)
         }
+        
+        if self.preferredContentSize.equalTo(CGSize.zero) {
+            self.preferredContentSize = CGSize(width: 680, height: 600)
+        }
+        
+        self.rootVC?.navigationItem.hidesBackButton = true
         
         return {}
     }()

--- a/Sources/DKImagePickerController/View/DKPermissionView.swift
+++ b/Sources/DKImagePickerController/View/DKPermissionView.swift
@@ -73,10 +73,10 @@ public class DKPermissionViewColors: NSObject {
                 forPhotoTitle photoTitle: UIColor = UIColor.gray,
                 forCameraTitle cameraTitle: UIColor = UIColor.white,
                 forButton button: UIColor = UIColor(red: 0, green: 122.0 / 255, blue: 1, alpha: 1)) {
-        backgroundColor = background
-        titlePhotoColor = photoTitle
-        titleCameraColor = cameraTitle
-        permitButtonColor = button
+        self.backgroundColor = background
+        self.titlePhotoColor = photoTitle
+        self.titleCameraColor = cameraTitle
+        self.permitButtonColor = button
     }
     
 }

--- a/Sources/DKImagePickerController/View/DKPermissionView.swift
+++ b/Sources/DKImagePickerController/View/DKPermissionView.swift
@@ -77,11 +77,6 @@ public class DKPermissionViewColors: NSObject {
         titlePhotoColor = photoTitle
         titleCameraColor = cameraTitle
         permitButtonColor = button
-        
-        print("init")
     }
     
-    deinit {
-        print("deinit")
-    }
 }

--- a/Sources/DKImagePickerController/View/DKPermissionView.swift
+++ b/Sources/DKImagePickerController/View/DKPermissionView.swift
@@ -77,5 +77,11 @@ public class DKPermissionViewColors: NSObject {
         titlePhotoColor = photoTitle
         titleCameraColor = cameraTitle
         permitButtonColor = button
+        
+        print("init")
+    }
+    
+    deinit {
+        print("deinit")
     }
 }

--- a/Sources/DKImagePickerController/View/DKPermissionView.swift
+++ b/Sources/DKImagePickerController/View/DKPermissionView.swift
@@ -45,7 +45,7 @@ open class DKPermissionView: UIView {
 	}
 	
 	open override func didMoveToWindow() {
-		super.didMoveToWindow()
+        super.didMoveToWindow()
 		
 		self.center = self.superview!.center
 	}


### PR DESCRIPTION
Some useful links to explain this problem:

> Incorrect designated initializer used.
>
> UIViewController has only one designated initializer init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?).
>
> As its comment says
>
>> The designated initializer. If you subclass UIViewController, you must call the super implementation of this method, even if you aren't using a NIB. (As a convenience, the default init method will do this for you, and specify nil for both of this methods arguments.) In the specified NIB, the File's Owner proxy should have its class set to your view controller subclass, with the view outlet connected to the main view. If you invoke this method with a nil nib name, then this class' -loadView method will attempt to load a NIB whose name is the same as your view controller's class. If no such NIB in fact exists then you must either call -setView: before -view is invoked, or override the -loadView method to set up your views programatically.
>
> So whenever you override the init() method of UIViewController, once you call super, UIViewController's implementation would call init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: NSBundle?) on behalf of you. So all the members in your UIViewController's subclass were initialized **twice**.

https://stackoverflow.com/questions/26310781/double-initialization-of-uiviewcontrollers-subclass-member-in-swift/26310782#26310782

https://stackoverflow.com/questions/27105185/unexplainable-memory-leak-swift-ios


Related topics:
- https://github.com/zhangao0086/DKImagePickerController/issues/258
- https://github.com/zhangao0086/DKImagePickerController/issues/482
- https://github.com/zhangao0086/DKImagePickerController/pull/535