### PR TITLE
Use optional for DKAssetGroup properties, and check index bound in fetchPHAsset

### DIFF
--- a/Sources/DKImageDataManager/DKImageGroupDataManager.swift
+++ b/Sources/DKImageDataManager/DKImageGroupDataManager.swift
@@ -137,7 +137,7 @@ open class DKImageGroupDataManager: DKImageBaseManager, PHPhotoLibraryChangeObse
 			return
 		}
 		
-        guard let lastResult = group.fetchResult.lastObject else {
+        guard let lastResult = group.fetchResult?.lastObject else {
             assertionFailure("Expect latestAsset")
             completeBlock(nil, nil)
             return
@@ -147,29 +147,43 @@ open class DKImageGroupDataManager: DKImageBaseManager, PHPhotoLibraryChangeObse
         latestAsset.fetchImage(with: size, options: options, completeBlock: completeBlock)
 	}
 	
-	open func fetchAsset(_ group: DKAssetGroup, index: Int) -> DKAsset {
-        let phAsset = fetchPHAsset(group, index: index)
+	open func fetchAsset(_ group: DKAssetGroup, index: Int) -> DKAsset? {
+        guard let phAsset = fetchPHAsset(group, index: index) else {
+            assertionFailure("Expect phAsset")
+            return nil
+        }
+
         if let asset = assets[phAsset.localIdentifier] {
             return asset
         }
 
-        let asset = DKAsset(originalAsset:phAsset)
+        let asset = DKAsset(originalAsset: phAsset)
         assets[phAsset.localIdentifier] = asset
         return asset
 	}
     
-    open func fetchPHAsset(_ group: DKAssetGroup, index: Int) -> PHAsset {
-        return group.fetchResult[group.fetchResult.count - 1 - index]
+    open func fetchPHAsset(_ group: DKAssetGroup, index: Int) -> PHAsset? {
+        guard let fetchResult = group.fetchResult else {
+            assertionFailure("Expect fetchResult")
+            return nil
+        }
+        let idx = fetchResult.count - 1 - index
+        guard idx >= 0 && fetchResult.count > idx else {
+            assertionFailure("idx out of range:\(idx) fetchResult count:\(fetchResult.count)")
+            return nil
+        }
+        return fetchResult[idx]
     }
     
     open func makeDKAssetGroup(with collection: PHAssetCollection) -> DKAssetGroup {
-        let assetGroup = DKAssetGroup()
-        assetGroup.groupId = collection.localIdentifier
+        let assetGroup = DKAssetGroup(groupId: collection.localIdentifier ?? "")
+
         self.updateGroup(assetGroup, collection: collection)
-        
-        let fetchResult = PHAsset.fetchAssets(in: collection, options: self.configuration.assetFetchOptions)
+
+        let fetchResult = PHAsset.fetchAssets(in: collection,
+                                              options: self.configuration.assetFetchOptions)
         self.updateGroup(assetGroup, fetchResult: fetchResult)
-        
+
         return assetGroup
     }
     
@@ -196,24 +210,26 @@ open class DKImageGroupDataManager: DKImageBaseManager, PHPhotoLibraryChangeObse
             completeBlock(groupIds, nil)
         }
     }
-	
-	open func updateGroup(_ group: DKAssetGroup, collection: PHAssetCollection) {
-		group.groupName = collection.localizedTitle
-		group.originalCollection = collection
-	}
-	
-	open func updateGroup(_ group: DKAssetGroup, fetchResult: PHFetchResult<PHAsset>) {
+
+    open func updateGroup(_ group: DKAssetGroup, collection: PHAssetCollection) {
+        group.groupName = collection.localizedTitle
+        group.originalCollection = collection
+    }
+
+    open func updateGroup(_ group: DKAssetGroup, fetchResult: PHFetchResult<PHAsset>) {
         group.fetchResult = fetchResult
         group.displayCount = self.configuration.fetchLimit
-	}
-    
+    }
+
 	// MARK: - PHPhotoLibraryChangeObserver methods
 	
 	open func photoLibraryDidChange(_ changeInstance: PHChange) {
         guard let groups = self.groups?.values else { return  }
         
         for group in groups {
-			if let changeDetails = changeInstance.changeDetails(for: group.originalCollection) {
+			if let originalCollection = group.originalCollection,
+                let changeDetails = changeInstance.changeDetails(for: originalCollection)
+            {
 				if changeDetails.objectWasDeleted {
 					self.groups?[group.groupId] = nil
                     notify(with: #selector(DKImageGroupDataManagerObserver.groupDidRemove(groupId:)),
@@ -222,7 +238,7 @@ open class DKImageGroupDataManager: DKImageBaseManager, PHPhotoLibraryChangeObse
 				}
 				
 				if let objectAfterChanges = changeDetails.objectAfterChanges {
-                    if let groupId = group.groupId, let groups = self.groups, let group = groups[groupId] {
+                    if let groups = self.groups, let group = groups[group.groupId] {
                         updateGroup(group, collection: objectAfterChanges)
                     } else {
                         assertionFailure("Expect group with id:\(group.groupId)")
@@ -232,19 +248,24 @@ open class DKImageGroupDataManager: DKImageBaseManager, PHPhotoLibraryChangeObse
 				}
 			}
 			
-			if let changeDetails = changeInstance.changeDetails(for: group.fetchResult) {
+			if let fetchResult = group.fetchResult, let changeDetails = changeInstance.changeDetails(for: fetchResult) {
                 let removedAssets = changeDetails.removedObjects.map{ DKAsset(originalAsset: $0) }
 				if removedAssets.count > 0 {
-                    self.notify(with: #selector(DKImageGroupDataManagerObserver.group(groupId:didRemoveAssets:)), object: group.groupId as AnyObject?, objectTwo: removedAssets as AnyObject?)
+                    self.notify(with: #selector(DKImageGroupDataManagerObserver.group(groupId:didRemoveAssets:)),
+                                object: group.groupId as AnyObject?,
+                                objectTwo: removedAssets as AnyObject?)
 				}
 				self.updateGroup(group, fetchResult: changeDetails.fetchResultAfterChanges)
 				
                 let insertedAssets = changeDetails.insertedObjects.map{ DKAsset(originalAsset: $0) }
 				if insertedAssets.count > 0  {
-                    self.notify(with: #selector(DKImageGroupDataManagerObserver.group(groupId:didInsertAssets:)), object: group.groupId as AnyObject?, objectTwo: insertedAssets as AnyObject?)
+                    self.notify(with: #selector(DKImageGroupDataManagerObserver.group(groupId:didInsertAssets:)),
+                                object: group.groupId as AnyObject?,
+                                objectTwo: insertedAssets as AnyObject?)
 				}
                 
-                self.notify(with: #selector(DKImageGroupDataManagerObserver.groupDidUpdateComplete(groupId:)), object: group.groupId as AnyObject?)
+                self.notify(with: #selector(DKImageGroupDataManagerObserver.groupDidUpdateComplete(groupId:)),
+                            object: group.groupId as AnyObject?)
             }
         }
         
@@ -264,7 +285,8 @@ open class DKImageGroupDataManager: DKImageBaseManager, PHPhotoLibraryChangeObse
         }
         
         if (insertedGroupIds.count > 0) {
-            self.notify(with: #selector(DKImageGroupDataManagerObserver.groupsDidInsert(groupIds:)), object: insertedGroupIds as AnyObject)
+            self.notify(with: #selector(DKImageGroupDataManagerObserver.groupsDidInsert(groupIds:)),
+                        object: insertedGroupIds as AnyObject)
         }
     }
 }

--- a/Sources/DKImageDataManager/Model/DKAssetGroup.swift
+++ b/Sources/DKImageDataManager/Model/DKAssetGroup.swift
@@ -10,9 +10,9 @@ import Photos
 
 /// A representation of a Photos asset grouping, such as a moment, user-created album, or smart album.
 public class DKAssetGroup: NSObject {
-	public let groupId: String
+    public let groupId: String
 
-	public var groupName: String?
+    public var groupName: String?
 
     public var originalCollection: PHAssetCollection?
     public var fetchResult: PHFetchResult<PHAsset>?

--- a/Sources/DKImageDataManager/Model/DKAssetGroup.swift
+++ b/Sources/DKImageDataManager/Model/DKAssetGroup.swift
@@ -10,11 +10,17 @@ import Photos
 
 /// A representation of a Photos asset grouping, such as a moment, user-created album, or smart album.
 public class DKAssetGroup: NSObject {
-	public var groupId: String!
-	public var groupName: String!
-    
+	public let groupId: String
+
+	public var groupName: String?
+
+    public var originalCollection: PHAssetCollection?
+    public var fetchResult: PHFetchResult<PHAsset>?
+
     public var totalCount: Int {
         get {
+            guard let fetchResult = fetchResult else { return 0 }
+
             if let displayCount = displayCount, displayCount > 0 {
                 return min(displayCount, fetchResult.count)
             } else {
@@ -24,7 +30,8 @@ public class DKAssetGroup: NSObject {
     }
     
     var displayCount: Int?
-	
-	public var originalCollection: PHAssetCollection!
-	public var fetchResult: PHFetchResult<PHAsset>!
+
+    init(groupId: String) {
+        self.groupId = groupId
+    }
 }

--- a/Sources/DKImagePickerController/DKImagePickerController.swift
+++ b/Sources/DKImagePickerController/DKImagePickerController.swift
@@ -603,7 +603,10 @@ open class DKImagePickerController: UINavigationController, DKImageBaseManagerOb
             
             var assets: [DKAsset] = []
             for index in 0 ..< group.totalCount {
-                let asset = self.groupDataManager.fetchAsset(group, index: index)
+                guard let asset = self.groupDataManager.fetchAsset(group, index: index) else {
+                    assertionFailure("Expect asset")
+                    continue
+                }
                 assets.append(asset)
             }
             

--- a/Sources/DKImagePickerController/View/DKAssetGroupDetailVC.swift
+++ b/Sources/DKImagePickerController/View/DKAssetGroupDetailVC.swift
@@ -230,7 +230,7 @@ open class DKAssetGroupDetailVC: UIViewController,
 		self.title = group.groupName
 		
 		let groupsCount = imagePickerController.groupDataManager.groupIds?.count ?? 0
-		self.selectGroupButton.setTitle(group.groupName + (groupsCount > 1 ? "  \u{25be}" : "" ), for: .normal)
+		self.selectGroupButton.setTitle(group.groupName ?? "" + (groupsCount > 1 ? "  \u{25be}" : "" ), for: .normal)
 		self.selectGroupButton.sizeToFit()
 		self.selectGroupButton.isEnabled = groupsCount > 1
 		
@@ -680,19 +680,20 @@ open class DKAssetGroupDetailVC: UIViewController,
         
         // Compute the assets to start caching and to stop caching.
         let (addedRects, removedRects) = self.differencesBetweenRects(self.previousPreheatRect, preheatRect)
+
         let addedAssets = addedRects
             .flatMap { rect in collectionView.indexPathsForElements(in: rect, self.hidesCamera) }
-            .map { indexPath in imagePickerController.groupDataManager.fetchPHAsset(group, index: indexPath.item) }
+            .flatMap { indexPath in imagePickerController.groupDataManager.fetchPHAsset(group, index: indexPath.item) }
         let removedAssets = removedRects
             .flatMap { rect in collectionView.indexPathsForElements(in: rect, self.hidesCamera) }
-            .map { indexPath in imagePickerController.groupDataManager.fetchPHAsset(group, index: indexPath.item) }
-        
+            .flatMap { indexPath in imagePickerController.groupDataManager.fetchPHAsset(group, index: indexPath.item) }
+
         // Update the assets the PHCachingImageManager is caching.
         getImageDataManager().startCachingAssets(for: addedAssets,
-                                             targetSize: self.thumbnailSize, contentMode: .aspectFill, options: nil)
+                                                 targetSize: self.thumbnailSize, contentMode: .aspectFill, options: nil)
         getImageDataManager().stopCachingAssets(for: removedAssets,
-                                            targetSize: self.thumbnailSize, contentMode: .aspectFill, options: nil)
-        
+                                                targetSize: self.thumbnailSize, contentMode: .aspectFill, options: nil)
+
         // Store the preheat rect to compare against in the future.
         self.previousPreheatRect = preheatRect
     }

--- a/Sources/DKImagePickerController/View/DKAssetGroupListVC.swift
+++ b/Sources/DKImagePickerController/View/DKAssetGroupListVC.swift
@@ -198,7 +198,7 @@ class DKAssetGroupListVC: UITableViewController, DKImageGroupDataManagerObserver
             for groupId in groups {
                 guard let group = self.groupDataManager.fetchGroup(with: groupId) else { continue }
                 
-                if defaultAssetGroup == group.originalCollection.assetCollectionSubtype {
+                if defaultAssetGroup == group.originalCollection?.assetCollectionSubtype {
                     return groupId
                 }
             }

--- a/Sources/Extensions/DKImageExtensionGallery.swift
+++ b/Sources/Extensions/DKImageExtensionGallery.swift
@@ -48,7 +48,10 @@ open class DKImageExtensionGallery: DKImageBaseExtension, DKPhotoGalleryDelegate
         var items = [DKPhotoGalleryItem]()
         
         for i in 0..<group.totalCount {
-            let phAsset = context.imagePickerController.groupDataManager.fetchPHAsset(group, index: i)
+            guard let phAsset = context.imagePickerController.groupDataManager.fetchPHAsset(group, index: i) else {
+                assertionFailure("Expect phAsset")
+                continue
+            }
             
             let item = DKPhotoGalleryItem(asset: phAsset)
             
@@ -113,16 +116,17 @@ open class DKImageExtensionGallery: DKImageBaseExtension, DKPhotoGalleryDelegate
     @objc open func selectAssetFromGallery(button: UIButton) {
         if let gallery = self.gallery {
             let currentIndex = gallery.currentIndex()
-            let asset = self.context.imagePickerController.groupDataManager.fetchAsset(self.group,
-                                                                                       index: currentIndex)
-            
-            if button.isSelected {
-                self.context.imagePickerController.deselect(asset: asset)
-            } else {
-                self.context.imagePickerController.select(asset: asset)
+            if let asset = self.context.imagePickerController.groupDataManager.fetchAsset(self.group,
+                                                                                          index: currentIndex)
+            {
+                if button.isSelected {
+                    self.context.imagePickerController.deselect(asset: asset)
+                } else {
+                    self.context.imagePickerController.select(asset: asset)
+                }
+
+                self.updateGalleryAssetSelection()
             }
-            
-            self.updateGalleryAssetSelection()
         }
     }
     
@@ -130,24 +134,25 @@ open class DKImageExtensionGallery: DKImageBaseExtension, DKPhotoGalleryDelegate
         if let gallery = self.gallery, let button = gallery.topViewController?.navigationItem.rightBarButtonItem?.customView as? UIButton {
             let currentIndex = gallery.currentIndex()
             
-            let asset = self.context.imagePickerController.groupDataManager.fetchAsset(self.group,
-                                                                                       index: currentIndex)
-            
-            var labelWidth: CGFloat = 0.0
-            if let selectedIndex = self.context.imagePickerController.index(of: asset) {
-                let title = "\(selectedIndex + 1)"
-                button.setTitle(title, for: .selected)
-                button.isSelected = true
-                
-                labelWidth = button.titleLabel!.sizeThatFits(CGSize(width: 100, height: 50)).width + 10
-            } else {
-                button.isSelected = false
-                button.sizeToFit()
+            if let asset = self.context.imagePickerController.groupDataManager.fetchAsset(self.group,
+                                                                                          index: currentIndex)
+            {
+                var labelWidth: CGFloat = 0.0
+                if let selectedIndex = self.context.imagePickerController.index(of: asset) {
+                    let title = "\(selectedIndex + 1)"
+                    button.setTitle(title, for: .selected)
+                    button.isSelected = true
+
+                    labelWidth = button.titleLabel!.sizeThatFits(CGSize(width: 100, height: 50)).width + 10
+                } else {
+                    button.isSelected = false
+                    button.sizeToFit()
+                }
+
+                button.bounds = CGRect(x: 0, y: 0,
+                                       width: max(button.backgroundImage(for: .normal)!.size.width, labelWidth),
+                                       height: button.bounds.height)
             }
-            
-            button.bounds = CGRect(x: 0, y: 0,
-                                   width: max(button.backgroundImage(for: .normal)!.size.width, labelWidth),
-                                   height: button.bounds.height)
         }
     }
     


### PR DESCRIPTION
DKAssetGroup's properties were all forced unwrapped, but when assigning values to them, some are optional e.g. localizedTitle - see crash in https://github.com/zhangao0086/DKImagePickerController/issues/574