### PR TITLE
Fix issue #564

### DIFF
--- a/Sources/DKImageDataManager/DKImageGroupDataManager.swift
+++ b/Sources/DKImageDataManager/DKImageGroupDataManager.swift
@@ -107,7 +107,9 @@ open class DKImageGroupDataManager: DKImageBaseManager, PHPhotoLibraryChangeObse
                 let assetGroup = strongSelf.makeDKAssetGroup(with: collection)
                 groups[assetGroup.groupId] = assetGroup
                 groupIds.append(assetGroup.groupId)
-                if !groupIds.isEmpty {
+                
+                // Filter the reloads to avoid frequetly reloadData() calling in collectionView
+                if !groupIds.isEmpty && collection.assetCollectionSubtype == .smartAlbumUserLibrary {
                     strongSelf.updatePartial(groups: groups, groupIds: groupIds, completeBlock: completeBlock)
                 }
             })
@@ -205,13 +207,13 @@ open class DKImageGroupDataManager: DKImageBaseManager, PHPhotoLibraryChangeObse
     open func updatePartial(groups: [String : DKAssetGroup], groupIds: [String], completeBlock: @escaping (_ groups: [String]?, _ error: NSError?) -> Void) {
         self.groups = groups
         self.groupIds = groupIds
-        
         DispatchQueue.main.async {
             completeBlock(groupIds, nil)
         }
     }
 
     open func updateGroup(_ group: DKAssetGroup, collection: PHAssetCollection) {
+        collection.assetCollectionType
         group.groupName = collection.localizedTitle
         group.originalCollection = collection
     }

--- a/Sources/DKImageDataManager/DKImageGroupDataManager.swift
+++ b/Sources/DKImageDataManager/DKImageGroupDataManager.swift
@@ -213,7 +213,6 @@ open class DKImageGroupDataManager: DKImageBaseManager, PHPhotoLibraryChangeObse
     }
 
     open func updateGroup(_ group: DKAssetGroup, collection: PHAssetCollection) {
-        collection.assetCollectionType
         group.groupName = collection.localizedTitle
         group.originalCollection = collection
     }


### PR DESCRIPTION
Fix issue #564 
Add .smartAlbumUserLibrary conditions into reload logic to avoid huge amount of collectionView.reloadData() calling while users have a large amount of groups in their albums.