### PR TITLE
Fix: create back button in DKImageExtensionGallery lazily 

### DIFF
--- a/Sources/Extensions/DKImageExtensionGallery.swift
+++ b/Sources/Extensions/DKImageExtensionGallery.swift
@@ -81,7 +81,7 @@ open class DKImageExtensionGallery: DKImageBaseExtension, DKPhotoGalleryDelegate
     
     // MARK: - DKPhotoGalleryDelegate
     
-    open var backItem = UIBarButtonItem(image: DKImagePickerControllerResource.photoGalleryBackArrowImage(),
+    open lazy var backItem = UIBarButtonItem(image: DKImagePickerControllerResource.photoGalleryBackArrowImage(),
                                            style: .plain,
                                            target: self,
                                            action: #selector(dismissGallery))


### PR DESCRIPTION
We've had a super strange issue on iOS 13.2 built by Xcode 11.1 (builds for iOS 12 worked just fine): back bar button item in `DKImageExtensionGallery` loses its target and becomes untappable. I suppose that's a compiler issue. This issue goes away if the bar button item is created lazily

Unfortunately, I did not succeed reproducing this issue on Example project, even adding iPad multi window support so I guess the real cause is some bug in UIKit or Xcode, but initialising bar button item lazily fixes the issue.