### PR TITLE
[DKImagePickerController] [Feature] Add videos album into list group abums.

### DIFF
--- a/Sources/DKImageDataManager/DKImageGroupDataManager.swift
+++ b/Sources/DKImageDataManager/DKImageGroupDataManager.swift
@@ -30,6 +30,7 @@ public class DKImageGroupDataManagerConfiguration: NSObject, NSCopying {
     /// The types of PHAssetCollection to display in the picker.
     public var assetGroupTypes: [PHAssetCollectionSubtype] = [
         .smartAlbumUserLibrary,
+        .smartAlbumVideos,
         .smartAlbumFavorites,
         .albumRegular
     ]


### PR DESCRIPTION
Currently, I can not see album that contains videos in photo libs. 
I found solution:  add smartAlbumVideos to assetGroupTypes in DKImageGroupDataManager.swift file
public var assetGroupTypes: [PHAssetCollectionSubtype] = [
        .smartAlbumUserLibrary,
        .smartAlbumVideos,
        .smartAlbumFavorites,
        .albumRegular
    ] 