### PR TITLE
Fix crash on going through multiple photos

### DIFF
--- a/Sources/DKImagePickerController/View/DKAssetGroupDetailVC.swift
+++ b/Sources/DKImagePickerController/View/DKAssetGroupDetailVC.swift
@@ -625,6 +625,12 @@ open class DKAssetGroupDetailVC: UIViewController,
         }
     }
 
+    public func collectionView(_ collectionView: UICollectionView, didEndDisplaying cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        let assetCell: DKAssetGroupDetailBaseCell? = cell as? DKAssetGroupDetailBaseCell
+
+        assetCell?.asset?.cancelRequests()
+    }
+
     public func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
         guard let imagePickerController = self.imagePickerController else {
             assertionFailure("Expect imagePickerController")


### PR DESCRIPTION
close https://github.com/zhangao0086/DKImagePickerController/issues/592

Fixed crashing on going through multiple photos speedy by cancelling loading.
