### PR TITLE
Adds compressing for not HEIC images

### DIFF
--- a/Sources/DKImagePickerController/DKImageAssetExporter.swift
+++ b/Sources/DKImagePickerController/DKImageAssetExporter.swift
@@ -447,6 +447,9 @@ open class DKImageAssetExporter: DKImageBaseManager {
                                         asset.fileName = fileName.dropLast(4) + "jpg"
                                     }
                                 }
+                            } else if self.configuration.compressionQuality < 1,
+                                let compressedData = self.imageToJPEG(with: imageData) { // Try to compress image
+                                imageData = compressedData
                             }
                             
                             asset.localTemporaryPath = asset.localTemporaryPath?.appendingPathComponent(asset.fileName!)


### PR DESCRIPTION
**Problem:** JPEG images are not compressed.
**Solution:** Check compression quality and try to compress data if we need it
Before compressing my file takes 4.2Mb, after compressing with quality 0.5 it takes 654Kb
 
@zhangao0086 Please, let me know that you think about this fix. 