### PR TITLE
Show the extensionType if DKImageExtension is not found

### DIFF
--- a/Sources/DKImagePickerController/DKImageExtensionController.swift
+++ b/Sources/DKImagePickerController/DKImageExtensionController.swift
@@ -110,7 +110,9 @@ open class DKImageExtensionController: NSObject {
             
             e?.perform(with: extraInfo)
         } else {
-            debugPrint("No DKImageExtension founed.")
+            // If the .camera extension is not found, then register it first using:
+            // DKImageExtensionController.registerExtension(extensionClass: DKImageExtensionCamera.self, for: .camera)
+            debugPrint("No DKImageExtension found: \(extensionType)")
         }
     }
     


### PR DESCRIPTION
I did not register the camera extension in my calling code, and got the "No DKImageExtension found" message.  This PR debug-prints the name of the extension it is looking for.

To avoid this error message in the first place, register the camera first by calling: 
DKImageExtensionController.registerExtension(extensionClass: DKImageExtensionCamera.self, for: .camera)