### PR TITLE
make request thumbnail size public

### DIFF
--- a/Sources/DKImagePickerController/DKImagePickerController.swift
+++ b/Sources/DKImagePickerController/DKImagePickerController.swift
@@ -134,6 +134,9 @@ open class DKImagePickerController: DKUINavigationController, DKImageBaseManager
     
     @objc public var exporter: DKImageAssetExporter?
     
+    /// Select view request thumbnail size
+    @objc public var thumbnailSize: CGSize = CGSizeZero
+    
     /// Indicates the status of the exporter.
     @objc public private(set) var exportStatus = DKImagePickerControllerExportStatus.none {
         willSet {
@@ -245,7 +248,9 @@ open class DKImagePickerController: DKUINavigationController, DKImageBaseManager
     }
     
     @objc open func makeRootVC() -> UIViewController & DKImagePickerControllerAware {
-      return DKAssetGroupDetailVC()
+        let groupVC = DKAssetGroupDetailVC()
+        groupVC.thumbnailSize = thumbnailSize
+        return groupVC
     }
     
     @objc open func presentCamera() {

--- a/Sources/DKImagePickerController/View/DKAssetGroupDetailVC.swift
+++ b/Sources/DKImagePickerController/View/DKAssetGroupDetailVC.swift
@@ -50,7 +50,7 @@ open class DKAssetGroupDetailVC: UIViewController,
     private var headerView: UIView?
     private var currentViewSize: CGSize?
     private var registeredCellIdentifiers = Set<String>()
-    private var thumbnailSize = CGSize.zero
+    public var thumbnailSize = CGSize.zero
     private var lastIndexPath: IndexPath?
     
     override open func viewDidLoad() {

--- a/Sources/Extensions/DKImageExtensionPhotoCropper.swift
+++ b/Sources/Extensions/DKImageExtensionPhotoCropper.swift
@@ -9,8 +9,8 @@
 import UIKit
 import Foundation
 
-#if canImport(TOCropViewController)
-import TOCropViewController
+#if canImport(CropViewController)
+import CropViewController
 #endif
 
 open class DKImageExtensionPhotoCropper: DKImageBaseExtension {
@@ -30,7 +30,7 @@ open class DKImageExtensionPhotoCropper: DKImageBaseExtension {
         self.metadata = extraInfo["metadata"] as? [AnyHashable : Any]
         self.didFinishEditing = didFinishEditing
         
-        let imageCropper = TOCropViewController(image: sourceImage)
+        let imageCropper = CropViewController(image: sourceImage)
         imageCropper.onDidCropToRect = { [weak self] image, _, _ in
             guard let strongSelf = self else { return }
             


### PR DESCRIPTION
Too many images and low memory iphone crash with memory limit.
So make thumbnail size to public let user set smaller size of  can avoid this crash.