### PR TITLE
Update PrivacyInfo.xcprivacy to include file timestamp

### DIFF
--- a/Sources/DKImagePickerController/Resource/Resources/PrivacyInfo.xcprivacy
+++ b/Sources/DKImagePickerController/Resource/Resources/PrivacyInfo.xcprivacy
@@ -5,7 +5,16 @@
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
 	<key>NSPrivacyAccessedAPITypes</key>
-	<array/>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>3B52.1</string>
+			</array>
+		</dict>
+	</array>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array/>
 	<key>NSPrivacyTracking</key>


### PR DESCRIPTION
Fixes #720

I picked reason `3B52.1` as the `DKAsset` refers to the photo or video that the user picked using the document picker controller.